### PR TITLE
Fix a potentially rare bug where some...

### DIFF
--- a/src/main/java/sg4e/ff4stats/fe/FlagSet.java
+++ b/src/main/java/sg4e/ff4stats/fe/FlagSet.java
@@ -39,10 +39,10 @@ import java.util.stream.Collectors;
 public class FlagSet {
     
     private final static Pattern BINARY_FLAGSET_PATTERN = Pattern.compile(
-            "b(?<version>[A-Za-z0-9_\\-]{4})" + // Version
+            "(?<binary>b(?<version>[A-Za-z0-9_\\-]{4})" + // Version
             "(?<flags>[A-Za-z0-9_\\-]*)" +      // Flags
             "(?:\\.(?<seed>[A-Z0-9]{1,10})" +   // Seed
-            "(?:\\.test\\.[0-9a-f]{8})?)?");    // Handler for test seeds
+            "(?:\\.test\\.[0-9a-f]{8})?)?)");    // Handler for test seeds
     
     private final TreeSet<Flag> flags = new TreeSet<>();
     private String version, binary;
@@ -242,14 +242,13 @@ public class FlagSet {
         
         if(!matcher.find())
             throw new IllegalArgumentException("Not a binary flag string");
-        String cleaned = binary.trim().substring(1);
         //next 4 chars encode version
         byte[] versionBytes = Base64.getUrlDecoder().decode(matcher.group("version"));
         int[] versionInts = new int[versionBytes.length];
         for(int i = 0; i < versionBytes.length; i++)
             versionInts[i] = (int) versionBytes[i];
         FlagSet flagSet = new FlagSet();
-        flagSet.setBinary(binary);
+        flagSet.setBinary(matcher.group("binary"));
         flagSet.setVersion(Arrays.stream(versionInts).mapToObj(Integer::toString).collect(Collectors.joining(".")));
         //next is {flags}.{seed}        
         byte[] flagStringDecoded = Base64.getUrlDecoder().decode(matcher.group("flags"));

--- a/src/main/java/sg4e/ff4stats/fe/FlagSet.java
+++ b/src/main/java/sg4e/ff4stats/fe/FlagSet.java
@@ -139,6 +139,10 @@ public class FlagSet {
         return "http://ff4fe.com/make?flags=" + toString().replaceAll(" ", "+");
     }
     
+    private static int ubyte(int value) {
+        return (value < 0) ? (value + 256) : value;
+    }
+    
     public static FlagSet from(String string) {
         if(BINARY_FLAGSET_PATTERN.matcher(string).find())
            return fromBinary(string);
@@ -256,12 +260,12 @@ public class FlagSet {
             int lowByteIndex = f.getOffset() >> 3;
             if(lowByteIndex < flagStringDecoded.length) {
                 int lowByteShift = f.getOffset() & 7;
-                decodedValue = flagStringDecoded[lowByteIndex] >> lowByteShift;
+                decodedValue = ubyte(flagStringDecoded[lowByteIndex]) >> lowByteShift;
                 int numOverflowBytes = ((f.getSize() - 1) >> 3) + 1;
                 for(int i = 1; i <= numOverflowBytes; i++) {
                     if(lowByteIndex + i >= flagStringDecoded.length)
                         break;
-                    decodedValue |= flagStringDecoded[lowByteIndex + i] << (8 * i - lowByteShift);
+                    decodedValue |= ubyte(flagStringDecoded[lowByteIndex + i]) << (8 * i - lowByteShift);
                 }
                 int mask = (1 << f.getSize()) - 1;
                 decodedValue &= mask;

--- a/src/main/java/sg4e/ff4stats/fe/FlagVersion.java
+++ b/src/main/java/sg4e/ff4stats/fe/FlagVersion.java
@@ -34,22 +34,23 @@ import sg4e.ff4stats.csv.*;
  * @author sg4e
  */
 public enum FlagVersion {
-    VERSION_3_0("3-0"),
-    VERSION_3_4("3-4"),
-    VERSION_3_5("3-5"),
-    VERSION_3_7("3-7");
+    VERSION_3_0("3-0", "bAAMD"),
+    VERSION_3_4("3-4", "bAAME"),
+    VERSION_3_5("3-5", "bAAMG"),
+    VERSION_3_7("3-7", "bAAMI");
     
     private static final HashSet<FlagVersion> triedVersions = new HashSet<>();
     private final List<Flag> flagSpec;
     private final Map<String, Flag> namesToFlags;
     private final Map<Flag, Integer> naturalOrder;
+    private final String binaryVersion;
     
     private static final Logger LOG = LoggerFactory.getLogger(FlagVersion.class);
     
     public static final String latest = "0.3.8";
     public static final String earliest = "0.3.0";
     
-    private FlagVersion(String filename) {
+    private FlagVersion(String filename, String binaryVersion) {
         String filePath = "fe/flagVersions/" + filename + ".csv";
         List<Flag> flags = new ArrayList<>();
         List<RecordParser> recordList = new ArrayList<>();
@@ -75,6 +76,11 @@ public enum FlagVersion {
             order.put(iter.next(), index++);
         }
         naturalOrder = Collections.unmodifiableMap(order);
+        this.binaryVersion = binaryVersion;
+    }
+     
+   public String getBinaryFlagVersion() {
+        return binaryVersion;
     }
     
     int compare(Flag a, Flag b) {

--- a/src/main/java/sg4e/ff4stats/fe/FlagVersion.java
+++ b/src/main/java/sg4e/ff4stats/fe/FlagVersion.java
@@ -89,19 +89,6 @@ public enum FlagVersion {
         return namesToFlags.get(name);
     }
     
-    /**
-     * Returns the FlagVersion associated with the provided version string. If
-     * the version is unrecognized/unsupported, the latest FlagVersion is
-     * returned. This behavior allows for the library to support future versions
-     * that do not alter the flag specification without needing recoding;
-     * however, newer flag specification that are not yet supported will cause
-     * errors elsewhere.
-     * 
-     * @param version the version string decoded from the FF4FE binary flag
-     * representation
-     * @return 
-     */
-    
     public static Flag getFlagFromFlagString(FlagVersion version, String flag, Flag previousFlag) {        
         for(Flag f : version.getAllFlags()) {
             if((previousFlag != null && previousFlag == f) || (flag.startsWith("-") && !flag.equals(f.getName())))
@@ -131,6 +118,19 @@ public enum FlagVersion {
         triedVersions.clear();
         return null;
     }
+    
+    /**
+     * Returns the FlagVersion associated with the provided version string. If
+     * the version is unrecognized/unsupported, the latest FlagVersion is
+     * returned. This behavior allows for the library to support future versions
+     * that do not alter the flag specification without needing recoding;
+     * however, newer flag specification that are not yet supported will cause
+     * errors elsewhere.
+     * 
+     * @param version the version string decoded from the FF4FE binary flag
+     * representation
+     * @return 
+     */
     
     public static FlagVersion getFromVersionString(String version) {
         switch(version) {

--- a/src/main/java/sg4e/ff4stats/fe/FlagVersion.java
+++ b/src/main/java/sg4e/ff4stats/fe/FlagVersion.java
@@ -46,7 +46,7 @@ public enum FlagVersion {
     
     private static final Logger LOG = LoggerFactory.getLogger(FlagVersion.class);
     
-    public static final String latest = "0.3.7";
+    public static final String latest = "0.3.8";
     public static final String earliest = "0.3.0";
     
     private FlagVersion(String filename) {
@@ -136,6 +136,7 @@ public enum FlagVersion {
         switch(version) {
             default:
                 LOG.warn("Unrecognized flag version {}; using latest", version);
+            case "0.3.8":
             case "0.3.7":
                 return VERSION_3_7;
             case "0.3.6":

--- a/src/test/java/sg4e/ff4stats/fe/FlagSetBinaryTest.java
+++ b/src/test/java/sg4e/ff4stats/fe/FlagSetBinaryTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 sg4e
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package sg4e.ff4stats.fe;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ *
+ * @author CaitSith2
+ */
+@RunWith(Parameterized.class)
+public class FlagSetBinaryTest {
+    //The only versions that can be tested are the latest version itself, and the latest version of the flagset that has
+    //a given flag before it was removed.  As a result, there is no way to test 0.3.4 or 0.3.5, as neither of those versions have
+    //flags that are NOT present in the latest version.
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { "bAAMDJCQEAMAJBa-OAQ", "Ji K Ps C -rescue T4gr S4 B -whyburn Gdmwl Etf Xsbk -myeyes -mute" }, 
+            { "bAAMIJCQEAMAJCl47", "Ji K Ps C -rescue T4gr S4 B -whyburn Gdmwl Etdf Xsbk" },
+        });
+    }
+    
+    @Parameterized.Parameter(0)
+    public String binaryFlagString;
+    
+    @Parameterized.Parameter(1)
+    public String flagString;
+    
+    @Test
+    public void testBinaryFlagEncoding() {
+        FlagSet binaryTest = FlagSet.fromString(flagString);
+        assertEquals(binaryTest.getBinary(), binaryFlagString);
+        assertFalse(binaryTest.hasSeed());
+    }
+    
+    @Test
+    public void testBinaryFlagDecoding() {
+        FlagSet binaryTest = FlagSet.fromBinary(binaryFlagString);
+        assertEquals(binaryTest.toString(), flagString);
+        assertFalse(binaryTest.hasSeed());
+    }
+}


### PR DESCRIPTION
...binary flags get decoded incorrectly.   It turns out that java8 sadly
has no unsigned int/unsigned byte primatives, and as a result, in
certain situations, if for example, a future flag addition/deletion
causes one of the flags of size 2 to be on offset 7/31/56/79, then the
decoder could end up decoding the value incorrectly, such that if there
was a flag that had a value of 3, it could end up decoind as 3, when it
should have decoded as 1.  (-128 >> 7 becomes -1,  -1 & 3 becomes 3.)