### PR TITLE
Split on ALL whitespace characters, not just space.  No more "Unrecog…

### DIFF
--- a/src/main/java/sg4e/ff4stats/fe/FlagSet.java
+++ b/src/main/java/sg4e/ff4stats/fe/FlagSet.java
@@ -192,7 +192,7 @@ public class FlagSet {
         
         FlagVersion version = FlagVersion.getFromVersionString(FlagVersion.latest);        
         
-        String[] parts = text.split(" ");
+        String[] parts = text.split("\\s+");
         List<Flag> allFlags = version.getAllFlags();
         FlagSet flagSet = new FlagSet();
         HashSet<String> flagStrings = new HashSet<>();


### PR DESCRIPTION
…nized flag: [no apparent flag here]" errors now.