### PR TITLE
Add GitHub Actions workflow to run tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: gradle
+
+      - name: Run tests
+        run: ./gradlew test


### PR DESCRIPTION
### Motivation
- Add continuous integration so the repository test suite runs automatically on GitHub for pushes and pull requests.

### Description
- Add `.github/workflows/tests.yml` which triggers on `push` and `pull_request`, uses `ubuntu-latest`, sets up Temurin Java 8 with Gradle caching via `actions/setup-java@v4`, and runs `./gradlew test`.

### Testing
- Ran `./gradlew test` locally and the build and test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c665edf0832da330b012e7cef9bb)