### PR TITLE
Add FlagVersion 4.5.0, canonical formatting for modern versions, and compatibility tests

### DIFF
--- a/src/main/java/sg4e/ff4stats/fe/FlagSet.java
+++ b/src/main/java/sg4e/ff4stats/fe/FlagSet.java
@@ -239,6 +239,12 @@ public class FlagSet {
         HashSet<String> incompatibleFlags = new HashSet<>();
         
         for(String part : parts) {
+            if ("Onone".equals(part)) {
+                // In modern upstream specs this token is implicit and does not have
+                // a concrete binary entry; ignore it during parse so the remainder
+                // of the flagset can be interpreted consistently.
+                continue;
+            }
             Flag previousFlag = null;
             while(part.length() > 0) {                
                 LOG.debug("-----\nOriginal part: " + part);

--- a/src/main/java/sg4e/ff4stats/fe/FlagSet.java
+++ b/src/main/java/sg4e/ff4stats/fe/FlagSet.java
@@ -296,12 +296,12 @@ public class FlagSet {
         flagRules.applyRules(flagSet, null);
         for (String part : flagStrings) {
             Flag flag = version.getFlagByName(part);
-            if(maxOffset < (flag.getOffset() + (flag.getSize() - 1)))
-                maxOffset = flag.getOffset() + (flag.getSize() - 1);
             if(flag == null) {
                 incompatibleFlags.add(part);
                 throw new IllegalArgumentException("Error: Incompatible flags specified: " + String.join(", ", incompatibleFlags));
             }
+            if(maxOffset < (flag.getOffset() + (flag.getSize() - 1)))
+                maxOffset = flag.getOffset() + (flag.getSize() - 1);
             flagSet.add(flag);
             flagRules.applyRules(flagSet, flag);
         }

--- a/src/main/java/sg4e/ff4stats/fe/FlagSet.java
+++ b/src/main/java/sg4e/ff4stats/fe/FlagSet.java
@@ -51,6 +51,7 @@ public class FlagSet {
     private String version, binary;
     private String seed = "";
     private String readableString = "uninitialized";
+    private boolean canonicalFormatting;
     private static final Logger LOG = LoggerFactory.getLogger(FlagSet.class); 
     
     private FlagSet() {
@@ -115,7 +116,15 @@ public class FlagSet {
     
     @Override
     public String toString() {
+        return canonicalFormatting ? toStringCanonical() : toStringLegacyStyle();
+    }
+
+    public String toStringLegacyStyle() {
         return readableString;
+    }
+
+    public String toStringCanonical() {
+        return sorted();
     }
     
     private String sorted() {
@@ -144,7 +153,12 @@ public class FlagSet {
         
         return s.toString();
     }
-    
+
+    private void configureFormattingMode() {
+        FlagVersion parsedVersion = FlagVersion.getFromVersionString(version);
+        this.canonicalFormatting = parsedVersion == FlagVersion.VERSION_4_0_0 || parsedVersion == FlagVersion.VERSION_4_5_0;
+    }
+
     public Boolean contains(String flagString) {
         for(Flag flag : flags)
             if(flag.getName().equals(flagString))
@@ -241,7 +255,8 @@ public class FlagSet {
                     LOG.error("Failed to update part due to exception: " + ex.getMessage());
                 }
                 
-                Flag flag = FlagVersion.getFlagFromFlagString(version, part.split(",")[0], previousFlag);
+                String flagToken = part.split(",")[0];
+                Flag flag = FlagVersion.getFlagFromFlagString(version, flagToken, previousFlag);
                 
                 if(flag == null) {
                     version = FlagVersion.getVersionFromFlagString(part);
@@ -251,8 +266,11 @@ public class FlagSet {
                             throw new IllegalArgumentException("Malformed human readable flag string: " + text);
                         throw new IllegalArgumentException("Error: Unrecognized flag: " + part);
                     }
-                    flag = FlagVersion.getFlagFromFlagString(version, part.split(",")[0], previousFlag);
-                    incompatibleFlags.add(flag.getName());
+                    flagToken = part.split(",")[0];
+                    flag = FlagVersion.getFlagFromFlagString(version, flagToken, previousFlag);
+                    if(flag == null) {
+                        throw new IllegalArgumentException("Error: Unrecognized flag: " + part);
+                    }
                 }
                 flagStrings.add(flag.getName());
                 if(flag.getName().length() == 1)
@@ -288,6 +306,7 @@ public class FlagSet {
             flagRules.applyRules(flagSet, flag);
         }
         flagSet.setVersion(version.getVersion());
+        flagSet.configureFormattingMode();
         flagSet.setReadableString(flagSet.sorted());
         
         maxOffset >>= 3;
@@ -352,6 +371,7 @@ public class FlagSet {
             if(decodedValue == f.getValue())
                 flagSet.add(f);
         });
+        flagSet.configureFormattingMode();
         flagSet.setReadableString(flagSet.sorted());
         
         return flagSet;

--- a/src/main/java/sg4e/ff4stats/fe/FlagVersion.java
+++ b/src/main/java/sg4e/ff4stats/fe/FlagVersion.java
@@ -44,7 +44,8 @@ public enum FlagVersion {
     VERSION_3_4("3-4", "bAAME",""),
     VERSION_3_5("3-5", "bAAMG",""),
     VERSION_3_7("3-7", "bAAMI",""),
-    VERSION_4_0_0("4-0-0", "bBAAA","/");
+    VERSION_4_0_0("4-0-0", "bBAAA","/"),
+    VERSION_4_5_0("4-5-0", "bBAUA","/");
     
     private final Logger log = LoggerFactory.getLogger(FlagVersion.class);
     private static final HashSet<FlagVersion> triedVersions = new HashSet<>();
@@ -58,7 +59,7 @@ public enum FlagVersion {
     
     private static final Logger LOG = LoggerFactory.getLogger(FlagVersion.class);
     
-    public static final String latest = "4.0.0";
+    public static final String latest = "4.5.0";
     public static final String earliest = "0.3.0";
     
     private FlagVersion(String filename, String binaryVersion, String seperator) {
@@ -215,6 +216,8 @@ public enum FlagVersion {
     }
     
     public static FlagVersion getVersionFromFlagString(String flag) {
+        if(getFlagFromFlagString(VERSION_4_5_0, flag, null) != null && !triedVersions.contains(VERSION_4_5_0))
+            return VERSION_4_5_0;
         if(getFlagFromFlagString(VERSION_4_0_0, flag, null) != null && !triedVersions.contains(VERSION_4_0_0))
             return VERSION_4_0_0;
         if(getFlagFromFlagString(VERSION_3_7, flag, null) != null && !triedVersions.contains(VERSION_3_7))
@@ -247,6 +250,8 @@ public enum FlagVersion {
         switch(version) {
             default:
                 LOG.warn("Unrecognized flag version {}; using latest", version);
+            case "4.5.0":
+                return VERSION_4_5_0;
             case "4.0.0":
                 return VERSION_4_0_0;
             case "0.3.8":

--- a/src/main/resources/fe/flagVersions/4-5-0.json
+++ b/src/main/resources/fe/flagVersions/4-5-0.json
@@ -1,0 +1,8158 @@
+{
+    "version": [
+        4,
+        5,
+        0
+    ],
+    "order": [
+        "Onone",
+        "Omode:classicforge",
+        "Omode:classicgiant",
+        "Omode:fiends",
+        "Omode:dkmatter",
+        "O1:char_cecil",
+        "O1:char_kain",
+        "O1:char_rydia",
+        "O1:char_tellah",
+        "O1:char_edward",
+        "O1:char_rosa",
+        "O1:char_yang",
+        "O1:char_palom",
+        "O1:char_porom",
+        "O1:char_cid",
+        "O1:char_edge",
+        "O1:char_fusoya",
+        "O1:boss_dmist",
+        "O1:boss_officer",
+        "O1:boss_octomamm",
+        "O1:boss_antlion",
+        "O1:boss_waterhag",
+        "O1:boss_mombomb",
+        "O1:boss_fabulgauntlet",
+        "O1:boss_milon",
+        "O1:boss_milonz",
+        "O1:boss_mirrorcecil",
+        "O1:boss_guard",
+        "O1:boss_karate",
+        "O1:boss_baigan",
+        "O1:boss_kainazzo",
+        "O1:boss_darkelf",
+        "O1:boss_magus",
+        "O1:boss_valvalis",
+        "O1:boss_calbrena",
+        "O1:boss_golbez",
+        "O1:boss_lugae",
+        "O1:boss_darkimp",
+        "O1:boss_kingqueen",
+        "O1:boss_rubicant",
+        "O1:boss_evilwall",
+        "O1:boss_asura",
+        "O1:boss_leviatan",
+        "O1:boss_odin",
+        "O1:boss_bahamut",
+        "O1:boss_elements",
+        "O1:boss_cpu",
+        "O1:boss_paledim",
+        "O1:boss_wyvern",
+        "O1:boss_plague",
+        "O1:boss_dlunar",
+        "O1:boss_ogopogo",
+        "O1:quest_mistcave",
+        "O1:quest_waterfall",
+        "O1:quest_antlionnest",
+        "O1:quest_hobs",
+        "O1:quest_fabul",
+        "O1:quest_ordeals",
+        "O1:quest_baroninn",
+        "O1:quest_baroncastle",
+        "O1:quest_magnes",
+        "O1:quest_zot",
+        "O1:quest_dwarfcastle",
+        "O1:quest_lowerbabil",
+        "O1:quest_falcon",
+        "O1:quest_sealedcave",
+        "O1:quest_monsterqueen",
+        "O1:quest_monsterking",
+        "O1:quest_baronbasement",
+        "O1:quest_giant",
+        "O1:quest_cavebahamut",
+        "O1:quest_murasamealtar",
+        "O1:quest_crystalaltar",
+        "O1:quest_whitealtar",
+        "O1:quest_ribbonaltar",
+        "O1:quest_masamunealtar",
+        "O1:quest_burnmist",
+        "O1:quest_curefever",
+        "O1:quest_unlocksewer",
+        "O1:quest_music",
+        "O1:quest_toroiatreasury",
+        "O1:quest_magma",
+        "O1:quest_supercannon",
+        "O1:quest_unlocksealedcave",
+        "O1:quest_bigwhale",
+        "O1:quest_traderat",
+        "O1:quest_forge",
+        "O1:quest_wakeyang",
+        "O1:quest_tradepan",
+        "O1:quest_tradepink",
+        "O1:quest_pass",
+        "O2:char_cecil",
+        "O2:char_kain",
+        "O2:char_rydia",
+        "O2:char_tellah",
+        "O2:char_edward",
+        "O2:char_rosa",
+        "O2:char_yang",
+        "O2:char_palom",
+        "O2:char_porom",
+        "O2:char_cid",
+        "O2:char_edge",
+        "O2:char_fusoya",
+        "O2:boss_dmist",
+        "O2:boss_officer",
+        "O2:boss_octomamm",
+        "O2:boss_antlion",
+        "O2:boss_waterhag",
+        "O2:boss_mombomb",
+        "O2:boss_fabulgauntlet",
+        "O2:boss_milon",
+        "O2:boss_milonz",
+        "O2:boss_mirrorcecil",
+        "O2:boss_guard",
+        "O2:boss_karate",
+        "O2:boss_baigan",
+        "O2:boss_kainazzo",
+        "O2:boss_darkelf",
+        "O2:boss_magus",
+        "O2:boss_valvalis",
+        "O2:boss_calbrena",
+        "O2:boss_golbez",
+        "O2:boss_lugae",
+        "O2:boss_darkimp",
+        "O2:boss_kingqueen",
+        "O2:boss_rubicant",
+        "O2:boss_evilwall",
+        "O2:boss_asura",
+        "O2:boss_leviatan",
+        "O2:boss_odin",
+        "O2:boss_bahamut",
+        "O2:boss_elements",
+        "O2:boss_cpu",
+        "O2:boss_paledim",
+        "O2:boss_wyvern",
+        "O2:boss_plague",
+        "O2:boss_dlunar",
+        "O2:boss_ogopogo",
+        "O2:quest_mistcave",
+        "O2:quest_waterfall",
+        "O2:quest_antlionnest",
+        "O2:quest_hobs",
+        "O2:quest_fabul",
+        "O2:quest_ordeals",
+        "O2:quest_baroninn",
+        "O2:quest_baroncastle",
+        "O2:quest_magnes",
+        "O2:quest_zot",
+        "O2:quest_dwarfcastle",
+        "O2:quest_lowerbabil",
+        "O2:quest_falcon",
+        "O2:quest_sealedcave",
+        "O2:quest_monsterqueen",
+        "O2:quest_monsterking",
+        "O2:quest_baronbasement",
+        "O2:quest_giant",
+        "O2:quest_cavebahamut",
+        "O2:quest_murasamealtar",
+        "O2:quest_crystalaltar",
+        "O2:quest_whitealtar",
+        "O2:quest_ribbonaltar",
+        "O2:quest_masamunealtar",
+        "O2:quest_burnmist",
+        "O2:quest_curefever",
+        "O2:quest_unlocksewer",
+        "O2:quest_music",
+        "O2:quest_toroiatreasury",
+        "O2:quest_magma",
+        "O2:quest_supercannon",
+        "O2:quest_unlocksealedcave",
+        "O2:quest_bigwhale",
+        "O2:quest_traderat",
+        "O2:quest_forge",
+        "O2:quest_wakeyang",
+        "O2:quest_tradepan",
+        "O2:quest_tradepink",
+        "O2:quest_pass",
+        "O3:char_cecil",
+        "O3:char_kain",
+        "O3:char_rydia",
+        "O3:char_tellah",
+        "O3:char_edward",
+        "O3:char_rosa",
+        "O3:char_yang",
+        "O3:char_palom",
+        "O3:char_porom",
+        "O3:char_cid",
+        "O3:char_edge",
+        "O3:char_fusoya",
+        "O3:boss_dmist",
+        "O3:boss_officer",
+        "O3:boss_octomamm",
+        "O3:boss_antlion",
+        "O3:boss_waterhag",
+        "O3:boss_mombomb",
+        "O3:boss_fabulgauntlet",
+        "O3:boss_milon",
+        "O3:boss_milonz",
+        "O3:boss_mirrorcecil",
+        "O3:boss_guard",
+        "O3:boss_karate",
+        "O3:boss_baigan",
+        "O3:boss_kainazzo",
+        "O3:boss_darkelf",
+        "O3:boss_magus",
+        "O3:boss_valvalis",
+        "O3:boss_calbrena",
+        "O3:boss_golbez",
+        "O3:boss_lugae",
+        "O3:boss_darkimp",
+        "O3:boss_kingqueen",
+        "O3:boss_rubicant",
+        "O3:boss_evilwall",
+        "O3:boss_asura",
+        "O3:boss_leviatan",
+        "O3:boss_odin",
+        "O3:boss_bahamut",
+        "O3:boss_elements",
+        "O3:boss_cpu",
+        "O3:boss_paledim",
+        "O3:boss_wyvern",
+        "O3:boss_plague",
+        "O3:boss_dlunar",
+        "O3:boss_ogopogo",
+        "O3:quest_mistcave",
+        "O3:quest_waterfall",
+        "O3:quest_antlionnest",
+        "O3:quest_hobs",
+        "O3:quest_fabul",
+        "O3:quest_ordeals",
+        "O3:quest_baroninn",
+        "O3:quest_baroncastle",
+        "O3:quest_magnes",
+        "O3:quest_zot",
+        "O3:quest_dwarfcastle",
+        "O3:quest_lowerbabil",
+        "O3:quest_falcon",
+        "O3:quest_sealedcave",
+        "O3:quest_monsterqueen",
+        "O3:quest_monsterking",
+        "O3:quest_baronbasement",
+        "O3:quest_giant",
+        "O3:quest_cavebahamut",
+        "O3:quest_murasamealtar",
+        "O3:quest_crystalaltar",
+        "O3:quest_whitealtar",
+        "O3:quest_ribbonaltar",
+        "O3:quest_masamunealtar",
+        "O3:quest_burnmist",
+        "O3:quest_curefever",
+        "O3:quest_unlocksewer",
+        "O3:quest_music",
+        "O3:quest_toroiatreasury",
+        "O3:quest_magma",
+        "O3:quest_supercannon",
+        "O3:quest_unlocksealedcave",
+        "O3:quest_bigwhale",
+        "O3:quest_traderat",
+        "O3:quest_forge",
+        "O3:quest_wakeyang",
+        "O3:quest_tradepan",
+        "O3:quest_tradepink",
+        "O3:quest_pass",
+        "O4:char_cecil",
+        "O4:char_kain",
+        "O4:char_rydia",
+        "O4:char_tellah",
+        "O4:char_edward",
+        "O4:char_rosa",
+        "O4:char_yang",
+        "O4:char_palom",
+        "O4:char_porom",
+        "O4:char_cid",
+        "O4:char_edge",
+        "O4:char_fusoya",
+        "O4:boss_dmist",
+        "O4:boss_officer",
+        "O4:boss_octomamm",
+        "O4:boss_antlion",
+        "O4:boss_waterhag",
+        "O4:boss_mombomb",
+        "O4:boss_fabulgauntlet",
+        "O4:boss_milon",
+        "O4:boss_milonz",
+        "O4:boss_mirrorcecil",
+        "O4:boss_guard",
+        "O4:boss_karate",
+        "O4:boss_baigan",
+        "O4:boss_kainazzo",
+        "O4:boss_darkelf",
+        "O4:boss_magus",
+        "O4:boss_valvalis",
+        "O4:boss_calbrena",
+        "O4:boss_golbez",
+        "O4:boss_lugae",
+        "O4:boss_darkimp",
+        "O4:boss_kingqueen",
+        "O4:boss_rubicant",
+        "O4:boss_evilwall",
+        "O4:boss_asura",
+        "O4:boss_leviatan",
+        "O4:boss_odin",
+        "O4:boss_bahamut",
+        "O4:boss_elements",
+        "O4:boss_cpu",
+        "O4:boss_paledim",
+        "O4:boss_wyvern",
+        "O4:boss_plague",
+        "O4:boss_dlunar",
+        "O4:boss_ogopogo",
+        "O4:quest_mistcave",
+        "O4:quest_waterfall",
+        "O4:quest_antlionnest",
+        "O4:quest_hobs",
+        "O4:quest_fabul",
+        "O4:quest_ordeals",
+        "O4:quest_baroninn",
+        "O4:quest_baroncastle",
+        "O4:quest_magnes",
+        "O4:quest_zot",
+        "O4:quest_dwarfcastle",
+        "O4:quest_lowerbabil",
+        "O4:quest_falcon",
+        "O4:quest_sealedcave",
+        "O4:quest_monsterqueen",
+        "O4:quest_monsterking",
+        "O4:quest_baronbasement",
+        "O4:quest_giant",
+        "O4:quest_cavebahamut",
+        "O4:quest_murasamealtar",
+        "O4:quest_crystalaltar",
+        "O4:quest_whitealtar",
+        "O4:quest_ribbonaltar",
+        "O4:quest_masamunealtar",
+        "O4:quest_burnmist",
+        "O4:quest_curefever",
+        "O4:quest_unlocksewer",
+        "O4:quest_music",
+        "O4:quest_toroiatreasury",
+        "O4:quest_magma",
+        "O4:quest_supercannon",
+        "O4:quest_unlocksealedcave",
+        "O4:quest_bigwhale",
+        "O4:quest_traderat",
+        "O4:quest_forge",
+        "O4:quest_wakeyang",
+        "O4:quest_tradepan",
+        "O4:quest_tradepink",
+        "O4:quest_pass",
+        "O5:char_cecil",
+        "O5:char_kain",
+        "O5:char_rydia",
+        "O5:char_tellah",
+        "O5:char_edward",
+        "O5:char_rosa",
+        "O5:char_yang",
+        "O5:char_palom",
+        "O5:char_porom",
+        "O5:char_cid",
+        "O5:char_edge",
+        "O5:char_fusoya",
+        "O5:boss_dmist",
+        "O5:boss_officer",
+        "O5:boss_octomamm",
+        "O5:boss_antlion",
+        "O5:boss_waterhag",
+        "O5:boss_mombomb",
+        "O5:boss_fabulgauntlet",
+        "O5:boss_milon",
+        "O5:boss_milonz",
+        "O5:boss_mirrorcecil",
+        "O5:boss_guard",
+        "O5:boss_karate",
+        "O5:boss_baigan",
+        "O5:boss_kainazzo",
+        "O5:boss_darkelf",
+        "O5:boss_magus",
+        "O5:boss_valvalis",
+        "O5:boss_calbrena",
+        "O5:boss_golbez",
+        "O5:boss_lugae",
+        "O5:boss_darkimp",
+        "O5:boss_kingqueen",
+        "O5:boss_rubicant",
+        "O5:boss_evilwall",
+        "O5:boss_asura",
+        "O5:boss_leviatan",
+        "O5:boss_odin",
+        "O5:boss_bahamut",
+        "O5:boss_elements",
+        "O5:boss_cpu",
+        "O5:boss_paledim",
+        "O5:boss_wyvern",
+        "O5:boss_plague",
+        "O5:boss_dlunar",
+        "O5:boss_ogopogo",
+        "O5:quest_mistcave",
+        "O5:quest_waterfall",
+        "O5:quest_antlionnest",
+        "O5:quest_hobs",
+        "O5:quest_fabul",
+        "O5:quest_ordeals",
+        "O5:quest_baroninn",
+        "O5:quest_baroncastle",
+        "O5:quest_magnes",
+        "O5:quest_zot",
+        "O5:quest_dwarfcastle",
+        "O5:quest_lowerbabil",
+        "O5:quest_falcon",
+        "O5:quest_sealedcave",
+        "O5:quest_monsterqueen",
+        "O5:quest_monsterking",
+        "O5:quest_baronbasement",
+        "O5:quest_giant",
+        "O5:quest_cavebahamut",
+        "O5:quest_murasamealtar",
+        "O5:quest_crystalaltar",
+        "O5:quest_whitealtar",
+        "O5:quest_ribbonaltar",
+        "O5:quest_masamunealtar",
+        "O5:quest_burnmist",
+        "O5:quest_curefever",
+        "O5:quest_unlocksewer",
+        "O5:quest_music",
+        "O5:quest_toroiatreasury",
+        "O5:quest_magma",
+        "O5:quest_supercannon",
+        "O5:quest_unlocksealedcave",
+        "O5:quest_bigwhale",
+        "O5:quest_traderat",
+        "O5:quest_forge",
+        "O5:quest_wakeyang",
+        "O5:quest_tradepan",
+        "O5:quest_tradepink",
+        "O5:quest_pass",
+        "O6:char_cecil",
+        "O6:char_kain",
+        "O6:char_rydia",
+        "O6:char_tellah",
+        "O6:char_edward",
+        "O6:char_rosa",
+        "O6:char_yang",
+        "O6:char_palom",
+        "O6:char_porom",
+        "O6:char_cid",
+        "O6:char_edge",
+        "O6:char_fusoya",
+        "O6:boss_dmist",
+        "O6:boss_officer",
+        "O6:boss_octomamm",
+        "O6:boss_antlion",
+        "O6:boss_waterhag",
+        "O6:boss_mombomb",
+        "O6:boss_fabulgauntlet",
+        "O6:boss_milon",
+        "O6:boss_milonz",
+        "O6:boss_mirrorcecil",
+        "O6:boss_guard",
+        "O6:boss_karate",
+        "O6:boss_baigan",
+        "O6:boss_kainazzo",
+        "O6:boss_darkelf",
+        "O6:boss_magus",
+        "O6:boss_valvalis",
+        "O6:boss_calbrena",
+        "O6:boss_golbez",
+        "O6:boss_lugae",
+        "O6:boss_darkimp",
+        "O6:boss_kingqueen",
+        "O6:boss_rubicant",
+        "O6:boss_evilwall",
+        "O6:boss_asura",
+        "O6:boss_leviatan",
+        "O6:boss_odin",
+        "O6:boss_bahamut",
+        "O6:boss_elements",
+        "O6:boss_cpu",
+        "O6:boss_paledim",
+        "O6:boss_wyvern",
+        "O6:boss_plague",
+        "O6:boss_dlunar",
+        "O6:boss_ogopogo",
+        "O6:quest_mistcave",
+        "O6:quest_waterfall",
+        "O6:quest_antlionnest",
+        "O6:quest_hobs",
+        "O6:quest_fabul",
+        "O6:quest_ordeals",
+        "O6:quest_baroninn",
+        "O6:quest_baroncastle",
+        "O6:quest_magnes",
+        "O6:quest_zot",
+        "O6:quest_dwarfcastle",
+        "O6:quest_lowerbabil",
+        "O6:quest_falcon",
+        "O6:quest_sealedcave",
+        "O6:quest_monsterqueen",
+        "O6:quest_monsterking",
+        "O6:quest_baronbasement",
+        "O6:quest_giant",
+        "O6:quest_cavebahamut",
+        "O6:quest_murasamealtar",
+        "O6:quest_crystalaltar",
+        "O6:quest_whitealtar",
+        "O6:quest_ribbonaltar",
+        "O6:quest_masamunealtar",
+        "O6:quest_burnmist",
+        "O6:quest_curefever",
+        "O6:quest_unlocksewer",
+        "O6:quest_music",
+        "O6:quest_toroiatreasury",
+        "O6:quest_magma",
+        "O6:quest_supercannon",
+        "O6:quest_unlocksealedcave",
+        "O6:quest_bigwhale",
+        "O6:quest_traderat",
+        "O6:quest_forge",
+        "O6:quest_wakeyang",
+        "O6:quest_tradepan",
+        "O6:quest_tradepink",
+        "O6:quest_pass",
+        "O7:char_cecil",
+        "O7:char_kain",
+        "O7:char_rydia",
+        "O7:char_tellah",
+        "O7:char_edward",
+        "O7:char_rosa",
+        "O7:char_yang",
+        "O7:char_palom",
+        "O7:char_porom",
+        "O7:char_cid",
+        "O7:char_edge",
+        "O7:char_fusoya",
+        "O7:boss_dmist",
+        "O7:boss_officer",
+        "O7:boss_octomamm",
+        "O7:boss_antlion",
+        "O7:boss_waterhag",
+        "O7:boss_mombomb",
+        "O7:boss_fabulgauntlet",
+        "O7:boss_milon",
+        "O7:boss_milonz",
+        "O7:boss_mirrorcecil",
+        "O7:boss_guard",
+        "O7:boss_karate",
+        "O7:boss_baigan",
+        "O7:boss_kainazzo",
+        "O7:boss_darkelf",
+        "O7:boss_magus",
+        "O7:boss_valvalis",
+        "O7:boss_calbrena",
+        "O7:boss_golbez",
+        "O7:boss_lugae",
+        "O7:boss_darkimp",
+        "O7:boss_kingqueen",
+        "O7:boss_rubicant",
+        "O7:boss_evilwall",
+        "O7:boss_asura",
+        "O7:boss_leviatan",
+        "O7:boss_odin",
+        "O7:boss_bahamut",
+        "O7:boss_elements",
+        "O7:boss_cpu",
+        "O7:boss_paledim",
+        "O7:boss_wyvern",
+        "O7:boss_plague",
+        "O7:boss_dlunar",
+        "O7:boss_ogopogo",
+        "O7:quest_mistcave",
+        "O7:quest_waterfall",
+        "O7:quest_antlionnest",
+        "O7:quest_hobs",
+        "O7:quest_fabul",
+        "O7:quest_ordeals",
+        "O7:quest_baroninn",
+        "O7:quest_baroncastle",
+        "O7:quest_magnes",
+        "O7:quest_zot",
+        "O7:quest_dwarfcastle",
+        "O7:quest_lowerbabil",
+        "O7:quest_falcon",
+        "O7:quest_sealedcave",
+        "O7:quest_monsterqueen",
+        "O7:quest_monsterking",
+        "O7:quest_baronbasement",
+        "O7:quest_giant",
+        "O7:quest_cavebahamut",
+        "O7:quest_murasamealtar",
+        "O7:quest_crystalaltar",
+        "O7:quest_whitealtar",
+        "O7:quest_ribbonaltar",
+        "O7:quest_masamunealtar",
+        "O7:quest_burnmist",
+        "O7:quest_curefever",
+        "O7:quest_unlocksewer",
+        "O7:quest_music",
+        "O7:quest_toroiatreasury",
+        "O7:quest_magma",
+        "O7:quest_supercannon",
+        "O7:quest_unlocksealedcave",
+        "O7:quest_bigwhale",
+        "O7:quest_traderat",
+        "O7:quest_forge",
+        "O7:quest_wakeyang",
+        "O7:quest_tradepan",
+        "O7:quest_tradepink",
+        "O7:quest_pass",
+        "O8:char_cecil",
+        "O8:char_kain",
+        "O8:char_rydia",
+        "O8:char_tellah",
+        "O8:char_edward",
+        "O8:char_rosa",
+        "O8:char_yang",
+        "O8:char_palom",
+        "O8:char_porom",
+        "O8:char_cid",
+        "O8:char_edge",
+        "O8:char_fusoya",
+        "O8:boss_dmist",
+        "O8:boss_officer",
+        "O8:boss_octomamm",
+        "O8:boss_antlion",
+        "O8:boss_waterhag",
+        "O8:boss_mombomb",
+        "O8:boss_fabulgauntlet",
+        "O8:boss_milon",
+        "O8:boss_milonz",
+        "O8:boss_mirrorcecil",
+        "O8:boss_guard",
+        "O8:boss_karate",
+        "O8:boss_baigan",
+        "O8:boss_kainazzo",
+        "O8:boss_darkelf",
+        "O8:boss_magus",
+        "O8:boss_valvalis",
+        "O8:boss_calbrena",
+        "O8:boss_golbez",
+        "O8:boss_lugae",
+        "O8:boss_darkimp",
+        "O8:boss_kingqueen",
+        "O8:boss_rubicant",
+        "O8:boss_evilwall",
+        "O8:boss_asura",
+        "O8:boss_leviatan",
+        "O8:boss_odin",
+        "O8:boss_bahamut",
+        "O8:boss_elements",
+        "O8:boss_cpu",
+        "O8:boss_paledim",
+        "O8:boss_wyvern",
+        "O8:boss_plague",
+        "O8:boss_dlunar",
+        "O8:boss_ogopogo",
+        "O8:quest_mistcave",
+        "O8:quest_waterfall",
+        "O8:quest_antlionnest",
+        "O8:quest_hobs",
+        "O8:quest_fabul",
+        "O8:quest_ordeals",
+        "O8:quest_baroninn",
+        "O8:quest_baroncastle",
+        "O8:quest_magnes",
+        "O8:quest_zot",
+        "O8:quest_dwarfcastle",
+        "O8:quest_lowerbabil",
+        "O8:quest_falcon",
+        "O8:quest_sealedcave",
+        "O8:quest_monsterqueen",
+        "O8:quest_monsterking",
+        "O8:quest_baronbasement",
+        "O8:quest_giant",
+        "O8:quest_cavebahamut",
+        "O8:quest_murasamealtar",
+        "O8:quest_crystalaltar",
+        "O8:quest_whitealtar",
+        "O8:quest_ribbonaltar",
+        "O8:quest_masamunealtar",
+        "O8:quest_burnmist",
+        "O8:quest_curefever",
+        "O8:quest_unlocksewer",
+        "O8:quest_music",
+        "O8:quest_toroiatreasury",
+        "O8:quest_magma",
+        "O8:quest_supercannon",
+        "O8:quest_unlocksealedcave",
+        "O8:quest_bigwhale",
+        "O8:quest_traderat",
+        "O8:quest_forge",
+        "O8:quest_wakeyang",
+        "O8:quest_tradepan",
+        "O8:quest_tradepink",
+        "O8:quest_pass",
+        "Orandom:1",
+        "Orandom:2",
+        "Orandom:3",
+        "Orandom:4",
+        "Orandom:5",
+        "Orandom:6",
+        "Orandom:7",
+        "Orandom:8",
+        "Orandom:quest",
+        "Orandom:tough_quest",
+        "Orandom:boss",
+        "Orandom:char",
+        "Oreq:all",
+        "Oreq:1",
+        "Oreq:2",
+        "Oreq:3",
+        "Oreq:4",
+        "Oreq:5",
+        "Oreq:6",
+        "Oreq:7",
+        "Oreq:8",
+        "Oreq:9",
+        "Oreq:10",
+        "Owin:game",
+        "Owin:crystal",
+        "Kvanilla",
+        "Kmain",
+        "Ksummon",
+        "Kmoon",
+        "Kmiab",
+        "Knofree",
+        "Kunsafe",
+        "Kforce:magma",
+        "Kforce:hook",
+        "Pnone",
+        "Pshop",
+        "Pkey",
+        "Pchests",
+        "Cvanilla",
+        "Cstandard",
+        "Crelaxed",
+        "Cnofree",
+        "Cnoearned",
+        "Cmaybe",
+        "Cdistinct:1",
+        "Cdistinct:2",
+        "Cdistinct:3",
+        "Cdistinct:4",
+        "Cdistinct:5",
+        "Cdistinct:6",
+        "Cdistinct:7",
+        "Cdistinct:8",
+        "Cdistinct:9",
+        "Cdistinct:10",
+        "Cdistinct:11",
+        "Cstart:cecil",
+        "Cstart:kain",
+        "Cstart:rydia",
+        "Cstart:tellah",
+        "Cstart:edward",
+        "Cstart:rosa",
+        "Cstart:yang",
+        "Cstart:palom",
+        "Cstart:porom",
+        "Cstart:cid",
+        "Cstart:edge",
+        "Cstart:fusoya",
+        "Cstart:any",
+        "Cstart:not_cecil",
+        "Cstart:not_kain",
+        "Cstart:not_rydia",
+        "Cstart:not_tellah",
+        "Cstart:not_edward",
+        "Cstart:not_rosa",
+        "Cstart:not_yang",
+        "Cstart:not_palom",
+        "Cstart:not_porom",
+        "Cstart:not_cid",
+        "Cstart:not_edge",
+        "Cstart:not_fusoya",
+        "Conly:cecil",
+        "Conly:kain",
+        "Conly:rydia",
+        "Conly:tellah",
+        "Conly:edward",
+        "Conly:rosa",
+        "Conly:yang",
+        "Conly:palom",
+        "Conly:porom",
+        "Conly:cid",
+        "Conly:edge",
+        "Conly:fusoya",
+        "Cno:cecil",
+        "Cno:kain",
+        "Cno:rydia",
+        "Cno:tellah",
+        "Cno:edward",
+        "Cno:rosa",
+        "Cno:yang",
+        "Cno:palom",
+        "Cno:porom",
+        "Cno:cid",
+        "Cno:edge",
+        "Cno:fusoya",
+        "Crestrict:cecil",
+        "Crestrict:kain",
+        "Crestrict:rydia",
+        "Crestrict:tellah",
+        "Crestrict:edward",
+        "Crestrict:rosa",
+        "Crestrict:yang",
+        "Crestrict:palom",
+        "Crestrict:porom",
+        "Crestrict:cid",
+        "Crestrict:edge",
+        "Crestrict:fusoya",
+        "Cj:spells",
+        "Cj:abilities",
+        "Cnekkie",
+        "Cnodupes",
+        "Cparty:1",
+        "Cparty:2",
+        "Cparty:3",
+        "Cparty:4",
+        "Cbye",
+        "Cpermajoin",
+        "Cpermadeath",
+        "Cpermadeader",
+        "Chero",
+        "Tvanilla",
+        "Tshuffle",
+        "Tstandard",
+        "Tpro",
+        "Twild",
+        "Twildish",
+        "Tempty",
+        "Tsparse:10",
+        "Tsparse:20",
+        "Tsparse:30",
+        "Tsparse:40",
+        "Tsparse:50",
+        "Tsparse:60",
+        "Tsparse:70",
+        "Tsparse:80",
+        "Tsparse:90",
+        "Tno:j",
+        "Tmaxtier:3",
+        "Tmaxtier:4",
+        "Tmaxtier:5",
+        "Tmaxtier:6",
+        "Tmaxtier:7",
+        "Tmoney",
+        "Tjunk",
+        "Svanilla",
+        "Sshuffle",
+        "Sstandard",
+        "Spro",
+        "Swild",
+        "Scabins",
+        "Sempty",
+        "Sfree",
+        "Ssell:quarter",
+        "Ssell:0",
+        "Sno:j",
+        "Sno:apples",
+        "Sno:sirens",
+        "Sno:life",
+        "Sunsafe",
+        "Bvanilla",
+        "Bstandard",
+        "Bnofree",
+        "Bunsafe",
+        "Balt:gauntlet",
+        "Bwhyburn",
+        "Bwhichburn",
+        "Evanilla",
+        "Etoggle",
+        "Ereduce",
+        "Enoencounters",
+        "Ekeep:doors",
+        "Ekeep:behemoths",
+        "Edanger",
+        "Ecantrun",
+        "Enoexp",
+        "Eno:jdrops",
+        "Eno:sirens",
+        "Gnone",
+        "Gdupe",
+        "Gmp",
+        "Gwarp",
+        "Glife",
+        "Gsylph",
+        "Gbackrow",
+        "G64",
+        "-kit:basic",
+        "-kit:better",
+        "-kit:loaded",
+        "-kit:cata",
+        "-kit:freedom",
+        "-kit:cid",
+        "-kit:yang",
+        "-kit:money",
+        "-kit:grabbag",
+        "-kit:miab",
+        "-kit:archer",
+        "-kit:fabul",
+        "-kit:castlevania",
+        "-kit:summon",
+        "-kit:notdeme",
+        "-kit:meme",
+        "-kit:defense",
+        "-kit:mist",
+        "-kit:mysidia",
+        "-kit:baron",
+        "-kit:dwarf",
+        "-kit:eblan",
+        "-kit:libra",
+        "-kit:99",
+        "-kit:green",
+        "-kit:random",
+        "-kit2:basic",
+        "-kit2:better",
+        "-kit2:loaded",
+        "-kit2:cata",
+        "-kit2:freedom",
+        "-kit2:cid",
+        "-kit2:yang",
+        "-kit2:money",
+        "-kit2:grabbag",
+        "-kit2:miab",
+        "-kit2:archer",
+        "-kit2:fabul",
+        "-kit2:castlevania",
+        "-kit2:summon",
+        "-kit2:notdeme",
+        "-kit2:meme",
+        "-kit2:defense",
+        "-kit2:mist",
+        "-kit2:mysidia",
+        "-kit2:baron",
+        "-kit2:dwarf",
+        "-kit2:eblan",
+        "-kit2:libra",
+        "-kit2:99",
+        "-kit2:green",
+        "-kit2:random",
+        "-kit3:basic",
+        "-kit3:better",
+        "-kit3:loaded",
+        "-kit3:cata",
+        "-kit3:freedom",
+        "-kit3:cid",
+        "-kit3:yang",
+        "-kit3:money",
+        "-kit3:grabbag",
+        "-kit3:miab",
+        "-kit3:archer",
+        "-kit3:fabul",
+        "-kit3:castlevania",
+        "-kit3:summon",
+        "-kit3:notdeme",
+        "-kit3:meme",
+        "-kit3:defense",
+        "-kit3:mist",
+        "-kit3:mysidia",
+        "-kit3:baron",
+        "-kit3:dwarf",
+        "-kit3:eblan",
+        "-kit3:libra",
+        "-kit3:99",
+        "-kit3:green",
+        "-kit3:random",
+        "-noadamants",
+        "-nocursed",
+        "-spoon",
+        "-smith:super",
+        "-smith:alt",
+        "-exp:split",
+        "-exp:noboost",
+        "-exp:nokeybonus",
+        "-vanilla:fusoya",
+        "-vanilla:agility",
+        "-vanilla:hobs",
+        "-vanilla:growup",
+        "-vanilla:fashion",
+        "-vanilla:miabs",
+        "-vanilla:giant",
+        "-vanilla:z",
+        "-vintage",
+        "-pushbtojump",
+        "-wacky:random",
+        "-wacky:musical",
+        "-wacky:bodyguard",
+        "-wacky:fistfight",
+        "-wacky:omnidextrous",
+        "-wacky:biggermagnet",
+        "-wacky:sixleggedrace",
+        "-wacky:floorislava",
+        "-wacky:neatfreak",
+        "-wacky:timeismoney",
+        "-wacky:nightmode",
+        "-wacky:mysteryjuice",
+        "-wacky:misspelled",
+        "-wacky:enemyunknown",
+        "-wacky:kleptomania",
+        "-wacky:darts",
+        "-wacky:unstackable",
+        "-wacky:menarepigs",
+        "-wacky:skywarriors",
+        "-wacky:zombies",
+        "-wacky:afflicted",
+        "-wacky:batman",
+        "-wacky:battlescars",
+        "-wacky:imaginarynumbers",
+        "-wacky:tellahmaneuver",
+        "-wacky:3point",
+        "-wacky:friendlyfire",
+        "-wacky:payablegolbez",
+        "-wacky:gottagofast",
+        "-wacky:worthfighting",
+        "-wacky:saveusbigchocobo",
+        "-wacky:isthisrandomized",
+        "-wacky:forwardisback",
+        "-spoil:all",
+        "-spoil:keyitems",
+        "-spoil:rewards",
+        "-spoil:chars",
+        "-spoil:treasure",
+        "-spoil:miabs",
+        "-spoil:shops",
+        "-spoil:bosses",
+        "-spoil:misc",
+        "-spoil:sparse10",
+        "-spoil:sparse20",
+        "-spoil:sparse30",
+        "-spoil:sparse40",
+        "-spoil:sparse50",
+        "-spoil:sparse60",
+        "-spoil:sparse70",
+        "-spoil:sparse80",
+        "-spoil:sparse90"
+    ],
+    "mutex": [
+        [
+            "O1:char_cecil",
+            "O1:char_kain",
+            "O1:char_rydia",
+            "O1:char_tellah",
+            "O1:char_edward",
+            "O1:char_rosa",
+            "O1:char_yang",
+            "O1:char_palom",
+            "O1:char_porom",
+            "O1:char_cid",
+            "O1:char_edge",
+            "O1:char_fusoya",
+            "O1:boss_dmist",
+            "O1:boss_officer",
+            "O1:boss_octomamm",
+            "O1:boss_antlion",
+            "O1:boss_waterhag",
+            "O1:boss_mombomb",
+            "O1:boss_fabulgauntlet",
+            "O1:boss_milon",
+            "O1:boss_milonz",
+            "O1:boss_mirrorcecil",
+            "O1:boss_guard",
+            "O1:boss_karate",
+            "O1:boss_baigan",
+            "O1:boss_kainazzo",
+            "O1:boss_darkelf",
+            "O1:boss_magus",
+            "O1:boss_valvalis",
+            "O1:boss_calbrena",
+            "O1:boss_golbez",
+            "O1:boss_lugae",
+            "O1:boss_darkimp",
+            "O1:boss_kingqueen",
+            "O1:boss_rubicant",
+            "O1:boss_evilwall",
+            "O1:boss_asura",
+            "O1:boss_leviatan",
+            "O1:boss_odin",
+            "O1:boss_bahamut",
+            "O1:boss_elements",
+            "O1:boss_cpu",
+            "O1:boss_paledim",
+            "O1:boss_wyvern",
+            "O1:boss_plague",
+            "O1:boss_dlunar",
+            "O1:boss_ogopogo",
+            "O1:quest_mistcave",
+            "O1:quest_waterfall",
+            "O1:quest_antlionnest",
+            "O1:quest_hobs",
+            "O1:quest_fabul",
+            "O1:quest_ordeals",
+            "O1:quest_baroninn",
+            "O1:quest_baroncastle",
+            "O1:quest_magnes",
+            "O1:quest_zot",
+            "O1:quest_dwarfcastle",
+            "O1:quest_lowerbabil",
+            "O1:quest_falcon",
+            "O1:quest_sealedcave",
+            "O1:quest_monsterqueen",
+            "O1:quest_monsterking",
+            "O1:quest_baronbasement",
+            "O1:quest_giant",
+            "O1:quest_cavebahamut",
+            "O1:quest_murasamealtar",
+            "O1:quest_crystalaltar",
+            "O1:quest_whitealtar",
+            "O1:quest_ribbonaltar",
+            "O1:quest_masamunealtar",
+            "O1:quest_burnmist",
+            "O1:quest_curefever",
+            "O1:quest_unlocksewer",
+            "O1:quest_music",
+            "O1:quest_toroiatreasury",
+            "O1:quest_magma",
+            "O1:quest_supercannon",
+            "O1:quest_unlocksealedcave",
+            "O1:quest_bigwhale",
+            "O1:quest_traderat",
+            "O1:quest_forge",
+            "O1:quest_wakeyang",
+            "O1:quest_tradepan",
+            "O1:quest_tradepink",
+            "O1:quest_pass"
+        ],
+        [
+            "O2:char_cecil",
+            "O2:char_kain",
+            "O2:char_rydia",
+            "O2:char_tellah",
+            "O2:char_edward",
+            "O2:char_rosa",
+            "O2:char_yang",
+            "O2:char_palom",
+            "O2:char_porom",
+            "O2:char_cid",
+            "O2:char_edge",
+            "O2:char_fusoya",
+            "O2:boss_dmist",
+            "O2:boss_officer",
+            "O2:boss_octomamm",
+            "O2:boss_antlion",
+            "O2:boss_waterhag",
+            "O2:boss_mombomb",
+            "O2:boss_fabulgauntlet",
+            "O2:boss_milon",
+            "O2:boss_milonz",
+            "O2:boss_mirrorcecil",
+            "O2:boss_guard",
+            "O2:boss_karate",
+            "O2:boss_baigan",
+            "O2:boss_kainazzo",
+            "O2:boss_darkelf",
+            "O2:boss_magus",
+            "O2:boss_valvalis",
+            "O2:boss_calbrena",
+            "O2:boss_golbez",
+            "O2:boss_lugae",
+            "O2:boss_darkimp",
+            "O2:boss_kingqueen",
+            "O2:boss_rubicant",
+            "O2:boss_evilwall",
+            "O2:boss_asura",
+            "O2:boss_leviatan",
+            "O2:boss_odin",
+            "O2:boss_bahamut",
+            "O2:boss_elements",
+            "O2:boss_cpu",
+            "O2:boss_paledim",
+            "O2:boss_wyvern",
+            "O2:boss_plague",
+            "O2:boss_dlunar",
+            "O2:boss_ogopogo",
+            "O2:quest_mistcave",
+            "O2:quest_waterfall",
+            "O2:quest_antlionnest",
+            "O2:quest_hobs",
+            "O2:quest_fabul",
+            "O2:quest_ordeals",
+            "O2:quest_baroninn",
+            "O2:quest_baroncastle",
+            "O2:quest_magnes",
+            "O2:quest_zot",
+            "O2:quest_dwarfcastle",
+            "O2:quest_lowerbabil",
+            "O2:quest_falcon",
+            "O2:quest_sealedcave",
+            "O2:quest_monsterqueen",
+            "O2:quest_monsterking",
+            "O2:quest_baronbasement",
+            "O2:quest_giant",
+            "O2:quest_cavebahamut",
+            "O2:quest_murasamealtar",
+            "O2:quest_crystalaltar",
+            "O2:quest_whitealtar",
+            "O2:quest_ribbonaltar",
+            "O2:quest_masamunealtar",
+            "O2:quest_burnmist",
+            "O2:quest_curefever",
+            "O2:quest_unlocksewer",
+            "O2:quest_music",
+            "O2:quest_toroiatreasury",
+            "O2:quest_magma",
+            "O2:quest_supercannon",
+            "O2:quest_unlocksealedcave",
+            "O2:quest_bigwhale",
+            "O2:quest_traderat",
+            "O2:quest_forge",
+            "O2:quest_wakeyang",
+            "O2:quest_tradepan",
+            "O2:quest_tradepink",
+            "O2:quest_pass"
+        ],
+        [
+            "O3:char_cecil",
+            "O3:char_kain",
+            "O3:char_rydia",
+            "O3:char_tellah",
+            "O3:char_edward",
+            "O3:char_rosa",
+            "O3:char_yang",
+            "O3:char_palom",
+            "O3:char_porom",
+            "O3:char_cid",
+            "O3:char_edge",
+            "O3:char_fusoya",
+            "O3:boss_dmist",
+            "O3:boss_officer",
+            "O3:boss_octomamm",
+            "O3:boss_antlion",
+            "O3:boss_waterhag",
+            "O3:boss_mombomb",
+            "O3:boss_fabulgauntlet",
+            "O3:boss_milon",
+            "O3:boss_milonz",
+            "O3:boss_mirrorcecil",
+            "O3:boss_guard",
+            "O3:boss_karate",
+            "O3:boss_baigan",
+            "O3:boss_kainazzo",
+            "O3:boss_darkelf",
+            "O3:boss_magus",
+            "O3:boss_valvalis",
+            "O3:boss_calbrena",
+            "O3:boss_golbez",
+            "O3:boss_lugae",
+            "O3:boss_darkimp",
+            "O3:boss_kingqueen",
+            "O3:boss_rubicant",
+            "O3:boss_evilwall",
+            "O3:boss_asura",
+            "O3:boss_leviatan",
+            "O3:boss_odin",
+            "O3:boss_bahamut",
+            "O3:boss_elements",
+            "O3:boss_cpu",
+            "O3:boss_paledim",
+            "O3:boss_wyvern",
+            "O3:boss_plague",
+            "O3:boss_dlunar",
+            "O3:boss_ogopogo",
+            "O3:quest_mistcave",
+            "O3:quest_waterfall",
+            "O3:quest_antlionnest",
+            "O3:quest_hobs",
+            "O3:quest_fabul",
+            "O3:quest_ordeals",
+            "O3:quest_baroninn",
+            "O3:quest_baroncastle",
+            "O3:quest_magnes",
+            "O3:quest_zot",
+            "O3:quest_dwarfcastle",
+            "O3:quest_lowerbabil",
+            "O3:quest_falcon",
+            "O3:quest_sealedcave",
+            "O3:quest_monsterqueen",
+            "O3:quest_monsterking",
+            "O3:quest_baronbasement",
+            "O3:quest_giant",
+            "O3:quest_cavebahamut",
+            "O3:quest_murasamealtar",
+            "O3:quest_crystalaltar",
+            "O3:quest_whitealtar",
+            "O3:quest_ribbonaltar",
+            "O3:quest_masamunealtar",
+            "O3:quest_burnmist",
+            "O3:quest_curefever",
+            "O3:quest_unlocksewer",
+            "O3:quest_music",
+            "O3:quest_toroiatreasury",
+            "O3:quest_magma",
+            "O3:quest_supercannon",
+            "O3:quest_unlocksealedcave",
+            "O3:quest_bigwhale",
+            "O3:quest_traderat",
+            "O3:quest_forge",
+            "O3:quest_wakeyang",
+            "O3:quest_tradepan",
+            "O3:quest_tradepink",
+            "O3:quest_pass"
+        ],
+        [
+            "O4:char_cecil",
+            "O4:char_kain",
+            "O4:char_rydia",
+            "O4:char_tellah",
+            "O4:char_edward",
+            "O4:char_rosa",
+            "O4:char_yang",
+            "O4:char_palom",
+            "O4:char_porom",
+            "O4:char_cid",
+            "O4:char_edge",
+            "O4:char_fusoya",
+            "O4:boss_dmist",
+            "O4:boss_officer",
+            "O4:boss_octomamm",
+            "O4:boss_antlion",
+            "O4:boss_waterhag",
+            "O4:boss_mombomb",
+            "O4:boss_fabulgauntlet",
+            "O4:boss_milon",
+            "O4:boss_milonz",
+            "O4:boss_mirrorcecil",
+            "O4:boss_guard",
+            "O4:boss_karate",
+            "O4:boss_baigan",
+            "O4:boss_kainazzo",
+            "O4:boss_darkelf",
+            "O4:boss_magus",
+            "O4:boss_valvalis",
+            "O4:boss_calbrena",
+            "O4:boss_golbez",
+            "O4:boss_lugae",
+            "O4:boss_darkimp",
+            "O4:boss_kingqueen",
+            "O4:boss_rubicant",
+            "O4:boss_evilwall",
+            "O4:boss_asura",
+            "O4:boss_leviatan",
+            "O4:boss_odin",
+            "O4:boss_bahamut",
+            "O4:boss_elements",
+            "O4:boss_cpu",
+            "O4:boss_paledim",
+            "O4:boss_wyvern",
+            "O4:boss_plague",
+            "O4:boss_dlunar",
+            "O4:boss_ogopogo",
+            "O4:quest_mistcave",
+            "O4:quest_waterfall",
+            "O4:quest_antlionnest",
+            "O4:quest_hobs",
+            "O4:quest_fabul",
+            "O4:quest_ordeals",
+            "O4:quest_baroninn",
+            "O4:quest_baroncastle",
+            "O4:quest_magnes",
+            "O4:quest_zot",
+            "O4:quest_dwarfcastle",
+            "O4:quest_lowerbabil",
+            "O4:quest_falcon",
+            "O4:quest_sealedcave",
+            "O4:quest_monsterqueen",
+            "O4:quest_monsterking",
+            "O4:quest_baronbasement",
+            "O4:quest_giant",
+            "O4:quest_cavebahamut",
+            "O4:quest_murasamealtar",
+            "O4:quest_crystalaltar",
+            "O4:quest_whitealtar",
+            "O4:quest_ribbonaltar",
+            "O4:quest_masamunealtar",
+            "O4:quest_burnmist",
+            "O4:quest_curefever",
+            "O4:quest_unlocksewer",
+            "O4:quest_music",
+            "O4:quest_toroiatreasury",
+            "O4:quest_magma",
+            "O4:quest_supercannon",
+            "O4:quest_unlocksealedcave",
+            "O4:quest_bigwhale",
+            "O4:quest_traderat",
+            "O4:quest_forge",
+            "O4:quest_wakeyang",
+            "O4:quest_tradepan",
+            "O4:quest_tradepink",
+            "O4:quest_pass"
+        ],
+        [
+            "O5:char_cecil",
+            "O5:char_kain",
+            "O5:char_rydia",
+            "O5:char_tellah",
+            "O5:char_edward",
+            "O5:char_rosa",
+            "O5:char_yang",
+            "O5:char_palom",
+            "O5:char_porom",
+            "O5:char_cid",
+            "O5:char_edge",
+            "O5:char_fusoya",
+            "O5:boss_dmist",
+            "O5:boss_officer",
+            "O5:boss_octomamm",
+            "O5:boss_antlion",
+            "O5:boss_waterhag",
+            "O5:boss_mombomb",
+            "O5:boss_fabulgauntlet",
+            "O5:boss_milon",
+            "O5:boss_milonz",
+            "O5:boss_mirrorcecil",
+            "O5:boss_guard",
+            "O5:boss_karate",
+            "O5:boss_baigan",
+            "O5:boss_kainazzo",
+            "O5:boss_darkelf",
+            "O5:boss_magus",
+            "O5:boss_valvalis",
+            "O5:boss_calbrena",
+            "O5:boss_golbez",
+            "O5:boss_lugae",
+            "O5:boss_darkimp",
+            "O5:boss_kingqueen",
+            "O5:boss_rubicant",
+            "O5:boss_evilwall",
+            "O5:boss_asura",
+            "O5:boss_leviatan",
+            "O5:boss_odin",
+            "O5:boss_bahamut",
+            "O5:boss_elements",
+            "O5:boss_cpu",
+            "O5:boss_paledim",
+            "O5:boss_wyvern",
+            "O5:boss_plague",
+            "O5:boss_dlunar",
+            "O5:boss_ogopogo",
+            "O5:quest_mistcave",
+            "O5:quest_waterfall",
+            "O5:quest_antlionnest",
+            "O5:quest_hobs",
+            "O5:quest_fabul",
+            "O5:quest_ordeals",
+            "O5:quest_baroninn",
+            "O5:quest_baroncastle",
+            "O5:quest_magnes",
+            "O5:quest_zot",
+            "O5:quest_dwarfcastle",
+            "O5:quest_lowerbabil",
+            "O5:quest_falcon",
+            "O5:quest_sealedcave",
+            "O5:quest_monsterqueen",
+            "O5:quest_monsterking",
+            "O5:quest_baronbasement",
+            "O5:quest_giant",
+            "O5:quest_cavebahamut",
+            "O5:quest_murasamealtar",
+            "O5:quest_crystalaltar",
+            "O5:quest_whitealtar",
+            "O5:quest_ribbonaltar",
+            "O5:quest_masamunealtar",
+            "O5:quest_burnmist",
+            "O5:quest_curefever",
+            "O5:quest_unlocksewer",
+            "O5:quest_music",
+            "O5:quest_toroiatreasury",
+            "O5:quest_magma",
+            "O5:quest_supercannon",
+            "O5:quest_unlocksealedcave",
+            "O5:quest_bigwhale",
+            "O5:quest_traderat",
+            "O5:quest_forge",
+            "O5:quest_wakeyang",
+            "O5:quest_tradepan",
+            "O5:quest_tradepink",
+            "O5:quest_pass"
+        ],
+        [
+            "O6:char_cecil",
+            "O6:char_kain",
+            "O6:char_rydia",
+            "O6:char_tellah",
+            "O6:char_edward",
+            "O6:char_rosa",
+            "O6:char_yang",
+            "O6:char_palom",
+            "O6:char_porom",
+            "O6:char_cid",
+            "O6:char_edge",
+            "O6:char_fusoya",
+            "O6:boss_dmist",
+            "O6:boss_officer",
+            "O6:boss_octomamm",
+            "O6:boss_antlion",
+            "O6:boss_waterhag",
+            "O6:boss_mombomb",
+            "O6:boss_fabulgauntlet",
+            "O6:boss_milon",
+            "O6:boss_milonz",
+            "O6:boss_mirrorcecil",
+            "O6:boss_guard",
+            "O6:boss_karate",
+            "O6:boss_baigan",
+            "O6:boss_kainazzo",
+            "O6:boss_darkelf",
+            "O6:boss_magus",
+            "O6:boss_valvalis",
+            "O6:boss_calbrena",
+            "O6:boss_golbez",
+            "O6:boss_lugae",
+            "O6:boss_darkimp",
+            "O6:boss_kingqueen",
+            "O6:boss_rubicant",
+            "O6:boss_evilwall",
+            "O6:boss_asura",
+            "O6:boss_leviatan",
+            "O6:boss_odin",
+            "O6:boss_bahamut",
+            "O6:boss_elements",
+            "O6:boss_cpu",
+            "O6:boss_paledim",
+            "O6:boss_wyvern",
+            "O6:boss_plague",
+            "O6:boss_dlunar",
+            "O6:boss_ogopogo",
+            "O6:quest_mistcave",
+            "O6:quest_waterfall",
+            "O6:quest_antlionnest",
+            "O6:quest_hobs",
+            "O6:quest_fabul",
+            "O6:quest_ordeals",
+            "O6:quest_baroninn",
+            "O6:quest_baroncastle",
+            "O6:quest_magnes",
+            "O6:quest_zot",
+            "O6:quest_dwarfcastle",
+            "O6:quest_lowerbabil",
+            "O6:quest_falcon",
+            "O6:quest_sealedcave",
+            "O6:quest_monsterqueen",
+            "O6:quest_monsterking",
+            "O6:quest_baronbasement",
+            "O6:quest_giant",
+            "O6:quest_cavebahamut",
+            "O6:quest_murasamealtar",
+            "O6:quest_crystalaltar",
+            "O6:quest_whitealtar",
+            "O6:quest_ribbonaltar",
+            "O6:quest_masamunealtar",
+            "O6:quest_burnmist",
+            "O6:quest_curefever",
+            "O6:quest_unlocksewer",
+            "O6:quest_music",
+            "O6:quest_toroiatreasury",
+            "O6:quest_magma",
+            "O6:quest_supercannon",
+            "O6:quest_unlocksealedcave",
+            "O6:quest_bigwhale",
+            "O6:quest_traderat",
+            "O6:quest_forge",
+            "O6:quest_wakeyang",
+            "O6:quest_tradepan",
+            "O6:quest_tradepink",
+            "O6:quest_pass"
+        ],
+        [
+            "O7:char_cecil",
+            "O7:char_kain",
+            "O7:char_rydia",
+            "O7:char_tellah",
+            "O7:char_edward",
+            "O7:char_rosa",
+            "O7:char_yang",
+            "O7:char_palom",
+            "O7:char_porom",
+            "O7:char_cid",
+            "O7:char_edge",
+            "O7:char_fusoya",
+            "O7:boss_dmist",
+            "O7:boss_officer",
+            "O7:boss_octomamm",
+            "O7:boss_antlion",
+            "O7:boss_waterhag",
+            "O7:boss_mombomb",
+            "O7:boss_fabulgauntlet",
+            "O7:boss_milon",
+            "O7:boss_milonz",
+            "O7:boss_mirrorcecil",
+            "O7:boss_guard",
+            "O7:boss_karate",
+            "O7:boss_baigan",
+            "O7:boss_kainazzo",
+            "O7:boss_darkelf",
+            "O7:boss_magus",
+            "O7:boss_valvalis",
+            "O7:boss_calbrena",
+            "O7:boss_golbez",
+            "O7:boss_lugae",
+            "O7:boss_darkimp",
+            "O7:boss_kingqueen",
+            "O7:boss_rubicant",
+            "O7:boss_evilwall",
+            "O7:boss_asura",
+            "O7:boss_leviatan",
+            "O7:boss_odin",
+            "O7:boss_bahamut",
+            "O7:boss_elements",
+            "O7:boss_cpu",
+            "O7:boss_paledim",
+            "O7:boss_wyvern",
+            "O7:boss_plague",
+            "O7:boss_dlunar",
+            "O7:boss_ogopogo",
+            "O7:quest_mistcave",
+            "O7:quest_waterfall",
+            "O7:quest_antlionnest",
+            "O7:quest_hobs",
+            "O7:quest_fabul",
+            "O7:quest_ordeals",
+            "O7:quest_baroninn",
+            "O7:quest_baroncastle",
+            "O7:quest_magnes",
+            "O7:quest_zot",
+            "O7:quest_dwarfcastle",
+            "O7:quest_lowerbabil",
+            "O7:quest_falcon",
+            "O7:quest_sealedcave",
+            "O7:quest_monsterqueen",
+            "O7:quest_monsterking",
+            "O7:quest_baronbasement",
+            "O7:quest_giant",
+            "O7:quest_cavebahamut",
+            "O7:quest_murasamealtar",
+            "O7:quest_crystalaltar",
+            "O7:quest_whitealtar",
+            "O7:quest_ribbonaltar",
+            "O7:quest_masamunealtar",
+            "O7:quest_burnmist",
+            "O7:quest_curefever",
+            "O7:quest_unlocksewer",
+            "O7:quest_music",
+            "O7:quest_toroiatreasury",
+            "O7:quest_magma",
+            "O7:quest_supercannon",
+            "O7:quest_unlocksealedcave",
+            "O7:quest_bigwhale",
+            "O7:quest_traderat",
+            "O7:quest_forge",
+            "O7:quest_wakeyang",
+            "O7:quest_tradepan",
+            "O7:quest_tradepink",
+            "O7:quest_pass"
+        ],
+        [
+            "O8:char_cecil",
+            "O8:char_kain",
+            "O8:char_rydia",
+            "O8:char_tellah",
+            "O8:char_edward",
+            "O8:char_rosa",
+            "O8:char_yang",
+            "O8:char_palom",
+            "O8:char_porom",
+            "O8:char_cid",
+            "O8:char_edge",
+            "O8:char_fusoya",
+            "O8:boss_dmist",
+            "O8:boss_officer",
+            "O8:boss_octomamm",
+            "O8:boss_antlion",
+            "O8:boss_waterhag",
+            "O8:boss_mombomb",
+            "O8:boss_fabulgauntlet",
+            "O8:boss_milon",
+            "O8:boss_milonz",
+            "O8:boss_mirrorcecil",
+            "O8:boss_guard",
+            "O8:boss_karate",
+            "O8:boss_baigan",
+            "O8:boss_kainazzo",
+            "O8:boss_darkelf",
+            "O8:boss_magus",
+            "O8:boss_valvalis",
+            "O8:boss_calbrena",
+            "O8:boss_golbez",
+            "O8:boss_lugae",
+            "O8:boss_darkimp",
+            "O8:boss_kingqueen",
+            "O8:boss_rubicant",
+            "O8:boss_evilwall",
+            "O8:boss_asura",
+            "O8:boss_leviatan",
+            "O8:boss_odin",
+            "O8:boss_bahamut",
+            "O8:boss_elements",
+            "O8:boss_cpu",
+            "O8:boss_paledim",
+            "O8:boss_wyvern",
+            "O8:boss_plague",
+            "O8:boss_dlunar",
+            "O8:boss_ogopogo",
+            "O8:quest_mistcave",
+            "O8:quest_waterfall",
+            "O8:quest_antlionnest",
+            "O8:quest_hobs",
+            "O8:quest_fabul",
+            "O8:quest_ordeals",
+            "O8:quest_baroninn",
+            "O8:quest_baroncastle",
+            "O8:quest_magnes",
+            "O8:quest_zot",
+            "O8:quest_dwarfcastle",
+            "O8:quest_lowerbabil",
+            "O8:quest_falcon",
+            "O8:quest_sealedcave",
+            "O8:quest_monsterqueen",
+            "O8:quest_monsterking",
+            "O8:quest_baronbasement",
+            "O8:quest_giant",
+            "O8:quest_cavebahamut",
+            "O8:quest_murasamealtar",
+            "O8:quest_crystalaltar",
+            "O8:quest_whitealtar",
+            "O8:quest_ribbonaltar",
+            "O8:quest_masamunealtar",
+            "O8:quest_burnmist",
+            "O8:quest_curefever",
+            "O8:quest_unlocksewer",
+            "O8:quest_music",
+            "O8:quest_toroiatreasury",
+            "O8:quest_magma",
+            "O8:quest_supercannon",
+            "O8:quest_unlocksealedcave",
+            "O8:quest_bigwhale",
+            "O8:quest_traderat",
+            "O8:quest_forge",
+            "O8:quest_wakeyang",
+            "O8:quest_tradepan",
+            "O8:quest_tradepink",
+            "O8:quest_pass"
+        ],
+        [
+            "Orandom:1",
+            "Orandom:2",
+            "Orandom:3",
+            "Orandom:4",
+            "Orandom:5",
+            "Orandom:6",
+            "Orandom:7",
+            "Orandom:8"
+        ],
+        [
+            "Orandom:quest",
+            "Orandom:tough_quest"
+        ],
+        [
+            "Oreq:all",
+            "Oreq:1",
+            "Oreq:2",
+            "Oreq:3",
+            "Oreq:4",
+            "Oreq:5",
+            "Oreq:6",
+            "Oreq:7",
+            "Oreq:8",
+            "Oreq:9",
+            "Oreq:10"
+        ],
+        [
+            "Owin:game",
+            "Owin:crystal"
+        ],
+        [
+            "Kforce:magma",
+            "Kforce:hook"
+        ],
+        [
+            "Cstandard",
+            "Crelaxed"
+        ],
+        [
+            "Cdistinct:1",
+            "Cdistinct:2",
+            "Cdistinct:3",
+            "Cdistinct:4",
+            "Cdistinct:5",
+            "Cdistinct:6",
+            "Cdistinct:7",
+            "Cdistinct:8",
+            "Cdistinct:9",
+            "Cdistinct:10",
+            "Cdistinct:11"
+        ],
+        [
+            "Cparty:1",
+            "Cparty:2",
+            "Cparty:3",
+            "Cparty:4"
+        ],
+        [
+            "Cpermadeath",
+            "Cpermadeader"
+        ],
+        [
+            "Tshuffle",
+            "Tstandard",
+            "Tpro",
+            "Twild",
+            "Twildish",
+            "Tempty"
+        ],
+        [
+            "Tsparse:10",
+            "Tsparse:20",
+            "Tsparse:30",
+            "Tsparse:40",
+            "Tsparse:50",
+            "Tsparse:60",
+            "Tsparse:70",
+            "Tsparse:80",
+            "Tsparse:90"
+        ],
+        [
+            "Tmaxtier:3",
+            "Tmaxtier:4",
+            "Tmaxtier:5",
+            "Tmaxtier:6",
+            "Tmaxtier:7"
+        ],
+        [
+            "Tmoney",
+            "Tjunk"
+        ],
+        [
+            "Sshuffle",
+            "Sstandard",
+            "Spro",
+            "Swild",
+            "Scabins",
+            "Sempty"
+        ],
+        [
+            "Ssell:quarter",
+            "Ssell:0"
+        ],
+        [
+            "Bwhyburn",
+            "Bwhichburn"
+        ],
+        [
+            "Etoggle",
+            "Ereduce",
+            "Enoencounters"
+        ],
+        [
+            "Eno:jdrops",
+            "Eno:sirens"
+        ],
+        [
+            "-kit:basic",
+            "-kit:better",
+            "-kit:loaded",
+            "-kit:cata",
+            "-kit:freedom",
+            "-kit:cid",
+            "-kit:yang",
+            "-kit:money",
+            "-kit:grabbag",
+            "-kit:miab",
+            "-kit:archer",
+            "-kit:fabul",
+            "-kit:castlevania",
+            "-kit:summon",
+            "-kit:notdeme",
+            "-kit:meme",
+            "-kit:defense",
+            "-kit:mist",
+            "-kit:mysidia",
+            "-kit:baron",
+            "-kit:dwarf",
+            "-kit:eblan",
+            "-kit:libra",
+            "-kit:99",
+            "-kit:green",
+            "-kit:random"
+        ],
+        [
+            "-kit2:basic",
+            "-kit2:better",
+            "-kit2:loaded",
+            "-kit2:cata",
+            "-kit2:freedom",
+            "-kit2:cid",
+            "-kit2:yang",
+            "-kit2:money",
+            "-kit2:grabbag",
+            "-kit2:miab",
+            "-kit2:archer",
+            "-kit2:fabul",
+            "-kit2:castlevania",
+            "-kit2:summon",
+            "-kit2:notdeme",
+            "-kit2:meme",
+            "-kit2:defense",
+            "-kit2:mist",
+            "-kit2:mysidia",
+            "-kit2:baron",
+            "-kit2:dwarf",
+            "-kit2:eblan",
+            "-kit2:libra",
+            "-kit2:99",
+            "-kit2:green",
+            "-kit2:random"
+        ],
+        [
+            "-kit3:basic",
+            "-kit3:better",
+            "-kit3:loaded",
+            "-kit3:cata",
+            "-kit3:freedom",
+            "-kit3:cid",
+            "-kit3:yang",
+            "-kit3:money",
+            "-kit3:grabbag",
+            "-kit3:miab",
+            "-kit3:archer",
+            "-kit3:fabul",
+            "-kit3:castlevania",
+            "-kit3:summon",
+            "-kit3:notdeme",
+            "-kit3:meme",
+            "-kit3:defense",
+            "-kit3:mist",
+            "-kit3:mysidia",
+            "-kit3:baron",
+            "-kit3:dwarf",
+            "-kit3:eblan",
+            "-kit3:libra",
+            "-kit3:99",
+            "-kit3:green",
+            "-kit3:random"
+        ],
+        [
+            "-smith:super",
+            "-smith:alt"
+        ],
+        [
+            "-wacky:random",
+            "-wacky:musical",
+            "-wacky:bodyguard",
+            "-wacky:fistfight",
+            "-wacky:omnidextrous",
+            "-wacky:biggermagnet",
+            "-wacky:sixleggedrace",
+            "-wacky:floorislava",
+            "-wacky:neatfreak",
+            "-wacky:timeismoney",
+            "-wacky:nightmode",
+            "-wacky:mysteryjuice",
+            "-wacky:misspelled",
+            "-wacky:enemyunknown",
+            "-wacky:kleptomania",
+            "-wacky:darts",
+            "-wacky:unstackable",
+            "-wacky:menarepigs",
+            "-wacky:skywarriors",
+            "-wacky:zombies",
+            "-wacky:afflicted",
+            "-wacky:batman",
+            "-wacky:battlescars",
+            "-wacky:imaginarynumbers",
+            "-wacky:tellahmaneuver",
+            "-wacky:3point",
+            "-wacky:friendlyfire",
+            "-wacky:payablegolbez",
+            "-wacky:gottagofast",
+            "-wacky:worthfighting",
+            "-wacky:saveusbigchocobo",
+            "-wacky:isthisrandomized",
+            "-wacky:forwardisback"
+        ],
+        [
+            "-spoil:treasure",
+            "-spoil:miabs"
+        ],
+        [
+            "-spoil:sparse10",
+            "-spoil:sparse20",
+            "-spoil:sparse30",
+            "-spoil:sparse40",
+            "-spoil:sparse50",
+            "-spoil:sparse60",
+            "-spoil:sparse70",
+            "-spoil:sparse80",
+            "-spoil:sparse90"
+        ]
+    ],
+    "binary": [
+        {
+            "flag": "Omode:classicforge",
+            "offset": 0,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Omode:classicgiant",
+            "offset": 1,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Omode:fiends",
+            "offset": 2,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Omode:dkmatter",
+            "offset": 3,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "O1:char_cecil",
+            "offset": 4,
+            "size": 7,
+            "value": 1
+        },
+        {
+            "flag": "O1:char_kain",
+            "offset": 4,
+            "size": 7,
+            "value": 2
+        },
+        {
+            "flag": "O1:char_rydia",
+            "offset": 4,
+            "size": 7,
+            "value": 3
+        },
+        {
+            "flag": "O1:char_tellah",
+            "offset": 4,
+            "size": 7,
+            "value": 4
+        },
+        {
+            "flag": "O1:char_edward",
+            "offset": 4,
+            "size": 7,
+            "value": 5
+        },
+        {
+            "flag": "O1:char_rosa",
+            "offset": 4,
+            "size": 7,
+            "value": 6
+        },
+        {
+            "flag": "O1:char_yang",
+            "offset": 4,
+            "size": 7,
+            "value": 7
+        },
+        {
+            "flag": "O1:char_palom",
+            "offset": 4,
+            "size": 7,
+            "value": 8
+        },
+        {
+            "flag": "O1:char_porom",
+            "offset": 4,
+            "size": 7,
+            "value": 9
+        },
+        {
+            "flag": "O1:char_cid",
+            "offset": 4,
+            "size": 7,
+            "value": 10
+        },
+        {
+            "flag": "O1:char_edge",
+            "offset": 4,
+            "size": 7,
+            "value": 11
+        },
+        {
+            "flag": "O1:char_fusoya",
+            "offset": 4,
+            "size": 7,
+            "value": 12
+        },
+        {
+            "flag": "O1:boss_dmist",
+            "offset": 4,
+            "size": 7,
+            "value": 13
+        },
+        {
+            "flag": "O1:boss_officer",
+            "offset": 4,
+            "size": 7,
+            "value": 14
+        },
+        {
+            "flag": "O1:boss_octomamm",
+            "offset": 4,
+            "size": 7,
+            "value": 15
+        },
+        {
+            "flag": "O1:boss_antlion",
+            "offset": 4,
+            "size": 7,
+            "value": 16
+        },
+        {
+            "flag": "O1:boss_waterhag",
+            "offset": 4,
+            "size": 7,
+            "value": 17
+        },
+        {
+            "flag": "O1:boss_mombomb",
+            "offset": 4,
+            "size": 7,
+            "value": 18
+        },
+        {
+            "flag": "O1:boss_fabulgauntlet",
+            "offset": 4,
+            "size": 7,
+            "value": 19
+        },
+        {
+            "flag": "O1:boss_milon",
+            "offset": 4,
+            "size": 7,
+            "value": 20
+        },
+        {
+            "flag": "O1:boss_milonz",
+            "offset": 4,
+            "size": 7,
+            "value": 21
+        },
+        {
+            "flag": "O1:boss_mirrorcecil",
+            "offset": 4,
+            "size": 7,
+            "value": 22
+        },
+        {
+            "flag": "O1:boss_guard",
+            "offset": 4,
+            "size": 7,
+            "value": 23
+        },
+        {
+            "flag": "O1:boss_karate",
+            "offset": 4,
+            "size": 7,
+            "value": 24
+        },
+        {
+            "flag": "O1:boss_baigan",
+            "offset": 4,
+            "size": 7,
+            "value": 25
+        },
+        {
+            "flag": "O1:boss_kainazzo",
+            "offset": 4,
+            "size": 7,
+            "value": 26
+        },
+        {
+            "flag": "O1:boss_darkelf",
+            "offset": 4,
+            "size": 7,
+            "value": 27
+        },
+        {
+            "flag": "O1:boss_magus",
+            "offset": 4,
+            "size": 7,
+            "value": 28
+        },
+        {
+            "flag": "O1:boss_valvalis",
+            "offset": 4,
+            "size": 7,
+            "value": 29
+        },
+        {
+            "flag": "O1:boss_calbrena",
+            "offset": 4,
+            "size": 7,
+            "value": 30
+        },
+        {
+            "flag": "O1:boss_golbez",
+            "offset": 4,
+            "size": 7,
+            "value": 31
+        },
+        {
+            "flag": "O1:boss_lugae",
+            "offset": 4,
+            "size": 7,
+            "value": 32
+        },
+        {
+            "flag": "O1:boss_darkimp",
+            "offset": 4,
+            "size": 7,
+            "value": 33
+        },
+        {
+            "flag": "O1:boss_kingqueen",
+            "offset": 4,
+            "size": 7,
+            "value": 34
+        },
+        {
+            "flag": "O1:boss_rubicant",
+            "offset": 4,
+            "size": 7,
+            "value": 35
+        },
+        {
+            "flag": "O1:boss_evilwall",
+            "offset": 4,
+            "size": 7,
+            "value": 36
+        },
+        {
+            "flag": "O1:boss_asura",
+            "offset": 4,
+            "size": 7,
+            "value": 37
+        },
+        {
+            "flag": "O1:boss_leviatan",
+            "offset": 4,
+            "size": 7,
+            "value": 38
+        },
+        {
+            "flag": "O1:boss_odin",
+            "offset": 4,
+            "size": 7,
+            "value": 39
+        },
+        {
+            "flag": "O1:boss_bahamut",
+            "offset": 4,
+            "size": 7,
+            "value": 40
+        },
+        {
+            "flag": "O1:boss_elements",
+            "offset": 4,
+            "size": 7,
+            "value": 41
+        },
+        {
+            "flag": "O1:boss_cpu",
+            "offset": 4,
+            "size": 7,
+            "value": 42
+        },
+        {
+            "flag": "O1:boss_paledim",
+            "offset": 4,
+            "size": 7,
+            "value": 43
+        },
+        {
+            "flag": "O1:boss_wyvern",
+            "offset": 4,
+            "size": 7,
+            "value": 44
+        },
+        {
+            "flag": "O1:boss_plague",
+            "offset": 4,
+            "size": 7,
+            "value": 45
+        },
+        {
+            "flag": "O1:boss_dlunar",
+            "offset": 4,
+            "size": 7,
+            "value": 46
+        },
+        {
+            "flag": "O1:boss_ogopogo",
+            "offset": 4,
+            "size": 7,
+            "value": 47
+        },
+        {
+            "flag": "O1:quest_mistcave",
+            "offset": 4,
+            "size": 7,
+            "value": 48
+        },
+        {
+            "flag": "O1:quest_waterfall",
+            "offset": 4,
+            "size": 7,
+            "value": 49
+        },
+        {
+            "flag": "O1:quest_antlionnest",
+            "offset": 4,
+            "size": 7,
+            "value": 50
+        },
+        {
+            "flag": "O1:quest_hobs",
+            "offset": 4,
+            "size": 7,
+            "value": 51
+        },
+        {
+            "flag": "O1:quest_fabul",
+            "offset": 4,
+            "size": 7,
+            "value": 52
+        },
+        {
+            "flag": "O1:quest_ordeals",
+            "offset": 4,
+            "size": 7,
+            "value": 53
+        },
+        {
+            "flag": "O1:quest_baroninn",
+            "offset": 4,
+            "size": 7,
+            "value": 54
+        },
+        {
+            "flag": "O1:quest_baroncastle",
+            "offset": 4,
+            "size": 7,
+            "value": 55
+        },
+        {
+            "flag": "O1:quest_magnes",
+            "offset": 4,
+            "size": 7,
+            "value": 56
+        },
+        {
+            "flag": "O1:quest_zot",
+            "offset": 4,
+            "size": 7,
+            "value": 57
+        },
+        {
+            "flag": "O1:quest_dwarfcastle",
+            "offset": 4,
+            "size": 7,
+            "value": 58
+        },
+        {
+            "flag": "O1:quest_lowerbabil",
+            "offset": 4,
+            "size": 7,
+            "value": 59
+        },
+        {
+            "flag": "O1:quest_falcon",
+            "offset": 4,
+            "size": 7,
+            "value": 60
+        },
+        {
+            "flag": "O1:quest_sealedcave",
+            "offset": 4,
+            "size": 7,
+            "value": 61
+        },
+        {
+            "flag": "O1:quest_monsterqueen",
+            "offset": 4,
+            "size": 7,
+            "value": 62
+        },
+        {
+            "flag": "O1:quest_monsterking",
+            "offset": 4,
+            "size": 7,
+            "value": 63
+        },
+        {
+            "flag": "O1:quest_baronbasement",
+            "offset": 4,
+            "size": 7,
+            "value": 64
+        },
+        {
+            "flag": "O1:quest_giant",
+            "offset": 4,
+            "size": 7,
+            "value": 65
+        },
+        {
+            "flag": "O1:quest_cavebahamut",
+            "offset": 4,
+            "size": 7,
+            "value": 66
+        },
+        {
+            "flag": "O1:quest_murasamealtar",
+            "offset": 4,
+            "size": 7,
+            "value": 67
+        },
+        {
+            "flag": "O1:quest_crystalaltar",
+            "offset": 4,
+            "size": 7,
+            "value": 68
+        },
+        {
+            "flag": "O1:quest_whitealtar",
+            "offset": 4,
+            "size": 7,
+            "value": 69
+        },
+        {
+            "flag": "O1:quest_ribbonaltar",
+            "offset": 4,
+            "size": 7,
+            "value": 70
+        },
+        {
+            "flag": "O1:quest_masamunealtar",
+            "offset": 4,
+            "size": 7,
+            "value": 71
+        },
+        {
+            "flag": "O1:quest_burnmist",
+            "offset": 4,
+            "size": 7,
+            "value": 72
+        },
+        {
+            "flag": "O1:quest_curefever",
+            "offset": 4,
+            "size": 7,
+            "value": 73
+        },
+        {
+            "flag": "O1:quest_unlocksewer",
+            "offset": 4,
+            "size": 7,
+            "value": 74
+        },
+        {
+            "flag": "O1:quest_music",
+            "offset": 4,
+            "size": 7,
+            "value": 75
+        },
+        {
+            "flag": "O1:quest_toroiatreasury",
+            "offset": 4,
+            "size": 7,
+            "value": 76
+        },
+        {
+            "flag": "O1:quest_magma",
+            "offset": 4,
+            "size": 7,
+            "value": 77
+        },
+        {
+            "flag": "O1:quest_supercannon",
+            "offset": 4,
+            "size": 7,
+            "value": 78
+        },
+        {
+            "flag": "O1:quest_unlocksealedcave",
+            "offset": 4,
+            "size": 7,
+            "value": 79
+        },
+        {
+            "flag": "O1:quest_bigwhale",
+            "offset": 4,
+            "size": 7,
+            "value": 80
+        },
+        {
+            "flag": "O1:quest_traderat",
+            "offset": 4,
+            "size": 7,
+            "value": 81
+        },
+        {
+            "flag": "O1:quest_forge",
+            "offset": 4,
+            "size": 7,
+            "value": 82
+        },
+        {
+            "flag": "O1:quest_wakeyang",
+            "offset": 4,
+            "size": 7,
+            "value": 83
+        },
+        {
+            "flag": "O1:quest_tradepan",
+            "offset": 4,
+            "size": 7,
+            "value": 84
+        },
+        {
+            "flag": "O1:quest_tradepink",
+            "offset": 4,
+            "size": 7,
+            "value": 85
+        },
+        {
+            "flag": "O1:quest_pass",
+            "offset": 4,
+            "size": 7,
+            "value": 86
+        },
+        {
+            "flag": "O2:char_cecil",
+            "offset": 11,
+            "size": 7,
+            "value": 1
+        },
+        {
+            "flag": "O2:char_kain",
+            "offset": 11,
+            "size": 7,
+            "value": 2
+        },
+        {
+            "flag": "O2:char_rydia",
+            "offset": 11,
+            "size": 7,
+            "value": 3
+        },
+        {
+            "flag": "O2:char_tellah",
+            "offset": 11,
+            "size": 7,
+            "value": 4
+        },
+        {
+            "flag": "O2:char_edward",
+            "offset": 11,
+            "size": 7,
+            "value": 5
+        },
+        {
+            "flag": "O2:char_rosa",
+            "offset": 11,
+            "size": 7,
+            "value": 6
+        },
+        {
+            "flag": "O2:char_yang",
+            "offset": 11,
+            "size": 7,
+            "value": 7
+        },
+        {
+            "flag": "O2:char_palom",
+            "offset": 11,
+            "size": 7,
+            "value": 8
+        },
+        {
+            "flag": "O2:char_porom",
+            "offset": 11,
+            "size": 7,
+            "value": 9
+        },
+        {
+            "flag": "O2:char_cid",
+            "offset": 11,
+            "size": 7,
+            "value": 10
+        },
+        {
+            "flag": "O2:char_edge",
+            "offset": 11,
+            "size": 7,
+            "value": 11
+        },
+        {
+            "flag": "O2:char_fusoya",
+            "offset": 11,
+            "size": 7,
+            "value": 12
+        },
+        {
+            "flag": "O2:boss_dmist",
+            "offset": 11,
+            "size": 7,
+            "value": 13
+        },
+        {
+            "flag": "O2:boss_officer",
+            "offset": 11,
+            "size": 7,
+            "value": 14
+        },
+        {
+            "flag": "O2:boss_octomamm",
+            "offset": 11,
+            "size": 7,
+            "value": 15
+        },
+        {
+            "flag": "O2:boss_antlion",
+            "offset": 11,
+            "size": 7,
+            "value": 16
+        },
+        {
+            "flag": "O2:boss_waterhag",
+            "offset": 11,
+            "size": 7,
+            "value": 17
+        },
+        {
+            "flag": "O2:boss_mombomb",
+            "offset": 11,
+            "size": 7,
+            "value": 18
+        },
+        {
+            "flag": "O2:boss_fabulgauntlet",
+            "offset": 11,
+            "size": 7,
+            "value": 19
+        },
+        {
+            "flag": "O2:boss_milon",
+            "offset": 11,
+            "size": 7,
+            "value": 20
+        },
+        {
+            "flag": "O2:boss_milonz",
+            "offset": 11,
+            "size": 7,
+            "value": 21
+        },
+        {
+            "flag": "O2:boss_mirrorcecil",
+            "offset": 11,
+            "size": 7,
+            "value": 22
+        },
+        {
+            "flag": "O2:boss_guard",
+            "offset": 11,
+            "size": 7,
+            "value": 23
+        },
+        {
+            "flag": "O2:boss_karate",
+            "offset": 11,
+            "size": 7,
+            "value": 24
+        },
+        {
+            "flag": "O2:boss_baigan",
+            "offset": 11,
+            "size": 7,
+            "value": 25
+        },
+        {
+            "flag": "O2:boss_kainazzo",
+            "offset": 11,
+            "size": 7,
+            "value": 26
+        },
+        {
+            "flag": "O2:boss_darkelf",
+            "offset": 11,
+            "size": 7,
+            "value": 27
+        },
+        {
+            "flag": "O2:boss_magus",
+            "offset": 11,
+            "size": 7,
+            "value": 28
+        },
+        {
+            "flag": "O2:boss_valvalis",
+            "offset": 11,
+            "size": 7,
+            "value": 29
+        },
+        {
+            "flag": "O2:boss_calbrena",
+            "offset": 11,
+            "size": 7,
+            "value": 30
+        },
+        {
+            "flag": "O2:boss_golbez",
+            "offset": 11,
+            "size": 7,
+            "value": 31
+        },
+        {
+            "flag": "O2:boss_lugae",
+            "offset": 11,
+            "size": 7,
+            "value": 32
+        },
+        {
+            "flag": "O2:boss_darkimp",
+            "offset": 11,
+            "size": 7,
+            "value": 33
+        },
+        {
+            "flag": "O2:boss_kingqueen",
+            "offset": 11,
+            "size": 7,
+            "value": 34
+        },
+        {
+            "flag": "O2:boss_rubicant",
+            "offset": 11,
+            "size": 7,
+            "value": 35
+        },
+        {
+            "flag": "O2:boss_evilwall",
+            "offset": 11,
+            "size": 7,
+            "value": 36
+        },
+        {
+            "flag": "O2:boss_asura",
+            "offset": 11,
+            "size": 7,
+            "value": 37
+        },
+        {
+            "flag": "O2:boss_leviatan",
+            "offset": 11,
+            "size": 7,
+            "value": 38
+        },
+        {
+            "flag": "O2:boss_odin",
+            "offset": 11,
+            "size": 7,
+            "value": 39
+        },
+        {
+            "flag": "O2:boss_bahamut",
+            "offset": 11,
+            "size": 7,
+            "value": 40
+        },
+        {
+            "flag": "O2:boss_elements",
+            "offset": 11,
+            "size": 7,
+            "value": 41
+        },
+        {
+            "flag": "O2:boss_cpu",
+            "offset": 11,
+            "size": 7,
+            "value": 42
+        },
+        {
+            "flag": "O2:boss_paledim",
+            "offset": 11,
+            "size": 7,
+            "value": 43
+        },
+        {
+            "flag": "O2:boss_wyvern",
+            "offset": 11,
+            "size": 7,
+            "value": 44
+        },
+        {
+            "flag": "O2:boss_plague",
+            "offset": 11,
+            "size": 7,
+            "value": 45
+        },
+        {
+            "flag": "O2:boss_dlunar",
+            "offset": 11,
+            "size": 7,
+            "value": 46
+        },
+        {
+            "flag": "O2:boss_ogopogo",
+            "offset": 11,
+            "size": 7,
+            "value": 47
+        },
+        {
+            "flag": "O2:quest_mistcave",
+            "offset": 11,
+            "size": 7,
+            "value": 48
+        },
+        {
+            "flag": "O2:quest_waterfall",
+            "offset": 11,
+            "size": 7,
+            "value": 49
+        },
+        {
+            "flag": "O2:quest_antlionnest",
+            "offset": 11,
+            "size": 7,
+            "value": 50
+        },
+        {
+            "flag": "O2:quest_hobs",
+            "offset": 11,
+            "size": 7,
+            "value": 51
+        },
+        {
+            "flag": "O2:quest_fabul",
+            "offset": 11,
+            "size": 7,
+            "value": 52
+        },
+        {
+            "flag": "O2:quest_ordeals",
+            "offset": 11,
+            "size": 7,
+            "value": 53
+        },
+        {
+            "flag": "O2:quest_baroninn",
+            "offset": 11,
+            "size": 7,
+            "value": 54
+        },
+        {
+            "flag": "O2:quest_baroncastle",
+            "offset": 11,
+            "size": 7,
+            "value": 55
+        },
+        {
+            "flag": "O2:quest_magnes",
+            "offset": 11,
+            "size": 7,
+            "value": 56
+        },
+        {
+            "flag": "O2:quest_zot",
+            "offset": 11,
+            "size": 7,
+            "value": 57
+        },
+        {
+            "flag": "O2:quest_dwarfcastle",
+            "offset": 11,
+            "size": 7,
+            "value": 58
+        },
+        {
+            "flag": "O2:quest_lowerbabil",
+            "offset": 11,
+            "size": 7,
+            "value": 59
+        },
+        {
+            "flag": "O2:quest_falcon",
+            "offset": 11,
+            "size": 7,
+            "value": 60
+        },
+        {
+            "flag": "O2:quest_sealedcave",
+            "offset": 11,
+            "size": 7,
+            "value": 61
+        },
+        {
+            "flag": "O2:quest_monsterqueen",
+            "offset": 11,
+            "size": 7,
+            "value": 62
+        },
+        {
+            "flag": "O2:quest_monsterking",
+            "offset": 11,
+            "size": 7,
+            "value": 63
+        },
+        {
+            "flag": "O2:quest_baronbasement",
+            "offset": 11,
+            "size": 7,
+            "value": 64
+        },
+        {
+            "flag": "O2:quest_giant",
+            "offset": 11,
+            "size": 7,
+            "value": 65
+        },
+        {
+            "flag": "O2:quest_cavebahamut",
+            "offset": 11,
+            "size": 7,
+            "value": 66
+        },
+        {
+            "flag": "O2:quest_murasamealtar",
+            "offset": 11,
+            "size": 7,
+            "value": 67
+        },
+        {
+            "flag": "O2:quest_crystalaltar",
+            "offset": 11,
+            "size": 7,
+            "value": 68
+        },
+        {
+            "flag": "O2:quest_whitealtar",
+            "offset": 11,
+            "size": 7,
+            "value": 69
+        },
+        {
+            "flag": "O2:quest_ribbonaltar",
+            "offset": 11,
+            "size": 7,
+            "value": 70
+        },
+        {
+            "flag": "O2:quest_masamunealtar",
+            "offset": 11,
+            "size": 7,
+            "value": 71
+        },
+        {
+            "flag": "O2:quest_burnmist",
+            "offset": 11,
+            "size": 7,
+            "value": 72
+        },
+        {
+            "flag": "O2:quest_curefever",
+            "offset": 11,
+            "size": 7,
+            "value": 73
+        },
+        {
+            "flag": "O2:quest_unlocksewer",
+            "offset": 11,
+            "size": 7,
+            "value": 74
+        },
+        {
+            "flag": "O2:quest_music",
+            "offset": 11,
+            "size": 7,
+            "value": 75
+        },
+        {
+            "flag": "O2:quest_toroiatreasury",
+            "offset": 11,
+            "size": 7,
+            "value": 76
+        },
+        {
+            "flag": "O2:quest_magma",
+            "offset": 11,
+            "size": 7,
+            "value": 77
+        },
+        {
+            "flag": "O2:quest_supercannon",
+            "offset": 11,
+            "size": 7,
+            "value": 78
+        },
+        {
+            "flag": "O2:quest_unlocksealedcave",
+            "offset": 11,
+            "size": 7,
+            "value": 79
+        },
+        {
+            "flag": "O2:quest_bigwhale",
+            "offset": 11,
+            "size": 7,
+            "value": 80
+        },
+        {
+            "flag": "O2:quest_traderat",
+            "offset": 11,
+            "size": 7,
+            "value": 81
+        },
+        {
+            "flag": "O2:quest_forge",
+            "offset": 11,
+            "size": 7,
+            "value": 82
+        },
+        {
+            "flag": "O2:quest_wakeyang",
+            "offset": 11,
+            "size": 7,
+            "value": 83
+        },
+        {
+            "flag": "O2:quest_tradepan",
+            "offset": 11,
+            "size": 7,
+            "value": 84
+        },
+        {
+            "flag": "O2:quest_tradepink",
+            "offset": 11,
+            "size": 7,
+            "value": 85
+        },
+        {
+            "flag": "O2:quest_pass",
+            "offset": 11,
+            "size": 7,
+            "value": 86
+        },
+        {
+            "flag": "O3:char_cecil",
+            "offset": 18,
+            "size": 7,
+            "value": 1
+        },
+        {
+            "flag": "O3:char_kain",
+            "offset": 18,
+            "size": 7,
+            "value": 2
+        },
+        {
+            "flag": "O3:char_rydia",
+            "offset": 18,
+            "size": 7,
+            "value": 3
+        },
+        {
+            "flag": "O3:char_tellah",
+            "offset": 18,
+            "size": 7,
+            "value": 4
+        },
+        {
+            "flag": "O3:char_edward",
+            "offset": 18,
+            "size": 7,
+            "value": 5
+        },
+        {
+            "flag": "O3:char_rosa",
+            "offset": 18,
+            "size": 7,
+            "value": 6
+        },
+        {
+            "flag": "O3:char_yang",
+            "offset": 18,
+            "size": 7,
+            "value": 7
+        },
+        {
+            "flag": "O3:char_palom",
+            "offset": 18,
+            "size": 7,
+            "value": 8
+        },
+        {
+            "flag": "O3:char_porom",
+            "offset": 18,
+            "size": 7,
+            "value": 9
+        },
+        {
+            "flag": "O3:char_cid",
+            "offset": 18,
+            "size": 7,
+            "value": 10
+        },
+        {
+            "flag": "O3:char_edge",
+            "offset": 18,
+            "size": 7,
+            "value": 11
+        },
+        {
+            "flag": "O3:char_fusoya",
+            "offset": 18,
+            "size": 7,
+            "value": 12
+        },
+        {
+            "flag": "O3:boss_dmist",
+            "offset": 18,
+            "size": 7,
+            "value": 13
+        },
+        {
+            "flag": "O3:boss_officer",
+            "offset": 18,
+            "size": 7,
+            "value": 14
+        },
+        {
+            "flag": "O3:boss_octomamm",
+            "offset": 18,
+            "size": 7,
+            "value": 15
+        },
+        {
+            "flag": "O3:boss_antlion",
+            "offset": 18,
+            "size": 7,
+            "value": 16
+        },
+        {
+            "flag": "O3:boss_waterhag",
+            "offset": 18,
+            "size": 7,
+            "value": 17
+        },
+        {
+            "flag": "O3:boss_mombomb",
+            "offset": 18,
+            "size": 7,
+            "value": 18
+        },
+        {
+            "flag": "O3:boss_fabulgauntlet",
+            "offset": 18,
+            "size": 7,
+            "value": 19
+        },
+        {
+            "flag": "O3:boss_milon",
+            "offset": 18,
+            "size": 7,
+            "value": 20
+        },
+        {
+            "flag": "O3:boss_milonz",
+            "offset": 18,
+            "size": 7,
+            "value": 21
+        },
+        {
+            "flag": "O3:boss_mirrorcecil",
+            "offset": 18,
+            "size": 7,
+            "value": 22
+        },
+        {
+            "flag": "O3:boss_guard",
+            "offset": 18,
+            "size": 7,
+            "value": 23
+        },
+        {
+            "flag": "O3:boss_karate",
+            "offset": 18,
+            "size": 7,
+            "value": 24
+        },
+        {
+            "flag": "O3:boss_baigan",
+            "offset": 18,
+            "size": 7,
+            "value": 25
+        },
+        {
+            "flag": "O3:boss_kainazzo",
+            "offset": 18,
+            "size": 7,
+            "value": 26
+        },
+        {
+            "flag": "O3:boss_darkelf",
+            "offset": 18,
+            "size": 7,
+            "value": 27
+        },
+        {
+            "flag": "O3:boss_magus",
+            "offset": 18,
+            "size": 7,
+            "value": 28
+        },
+        {
+            "flag": "O3:boss_valvalis",
+            "offset": 18,
+            "size": 7,
+            "value": 29
+        },
+        {
+            "flag": "O3:boss_calbrena",
+            "offset": 18,
+            "size": 7,
+            "value": 30
+        },
+        {
+            "flag": "O3:boss_golbez",
+            "offset": 18,
+            "size": 7,
+            "value": 31
+        },
+        {
+            "flag": "O3:boss_lugae",
+            "offset": 18,
+            "size": 7,
+            "value": 32
+        },
+        {
+            "flag": "O3:boss_darkimp",
+            "offset": 18,
+            "size": 7,
+            "value": 33
+        },
+        {
+            "flag": "O3:boss_kingqueen",
+            "offset": 18,
+            "size": 7,
+            "value": 34
+        },
+        {
+            "flag": "O3:boss_rubicant",
+            "offset": 18,
+            "size": 7,
+            "value": 35
+        },
+        {
+            "flag": "O3:boss_evilwall",
+            "offset": 18,
+            "size": 7,
+            "value": 36
+        },
+        {
+            "flag": "O3:boss_asura",
+            "offset": 18,
+            "size": 7,
+            "value": 37
+        },
+        {
+            "flag": "O3:boss_leviatan",
+            "offset": 18,
+            "size": 7,
+            "value": 38
+        },
+        {
+            "flag": "O3:boss_odin",
+            "offset": 18,
+            "size": 7,
+            "value": 39
+        },
+        {
+            "flag": "O3:boss_bahamut",
+            "offset": 18,
+            "size": 7,
+            "value": 40
+        },
+        {
+            "flag": "O3:boss_elements",
+            "offset": 18,
+            "size": 7,
+            "value": 41
+        },
+        {
+            "flag": "O3:boss_cpu",
+            "offset": 18,
+            "size": 7,
+            "value": 42
+        },
+        {
+            "flag": "O3:boss_paledim",
+            "offset": 18,
+            "size": 7,
+            "value": 43
+        },
+        {
+            "flag": "O3:boss_wyvern",
+            "offset": 18,
+            "size": 7,
+            "value": 44
+        },
+        {
+            "flag": "O3:boss_plague",
+            "offset": 18,
+            "size": 7,
+            "value": 45
+        },
+        {
+            "flag": "O3:boss_dlunar",
+            "offset": 18,
+            "size": 7,
+            "value": 46
+        },
+        {
+            "flag": "O3:boss_ogopogo",
+            "offset": 18,
+            "size": 7,
+            "value": 47
+        },
+        {
+            "flag": "O3:quest_mistcave",
+            "offset": 18,
+            "size": 7,
+            "value": 48
+        },
+        {
+            "flag": "O3:quest_waterfall",
+            "offset": 18,
+            "size": 7,
+            "value": 49
+        },
+        {
+            "flag": "O3:quest_antlionnest",
+            "offset": 18,
+            "size": 7,
+            "value": 50
+        },
+        {
+            "flag": "O3:quest_hobs",
+            "offset": 18,
+            "size": 7,
+            "value": 51
+        },
+        {
+            "flag": "O3:quest_fabul",
+            "offset": 18,
+            "size": 7,
+            "value": 52
+        },
+        {
+            "flag": "O3:quest_ordeals",
+            "offset": 18,
+            "size": 7,
+            "value": 53
+        },
+        {
+            "flag": "O3:quest_baroninn",
+            "offset": 18,
+            "size": 7,
+            "value": 54
+        },
+        {
+            "flag": "O3:quest_baroncastle",
+            "offset": 18,
+            "size": 7,
+            "value": 55
+        },
+        {
+            "flag": "O3:quest_magnes",
+            "offset": 18,
+            "size": 7,
+            "value": 56
+        },
+        {
+            "flag": "O3:quest_zot",
+            "offset": 18,
+            "size": 7,
+            "value": 57
+        },
+        {
+            "flag": "O3:quest_dwarfcastle",
+            "offset": 18,
+            "size": 7,
+            "value": 58
+        },
+        {
+            "flag": "O3:quest_lowerbabil",
+            "offset": 18,
+            "size": 7,
+            "value": 59
+        },
+        {
+            "flag": "O3:quest_falcon",
+            "offset": 18,
+            "size": 7,
+            "value": 60
+        },
+        {
+            "flag": "O3:quest_sealedcave",
+            "offset": 18,
+            "size": 7,
+            "value": 61
+        },
+        {
+            "flag": "O3:quest_monsterqueen",
+            "offset": 18,
+            "size": 7,
+            "value": 62
+        },
+        {
+            "flag": "O3:quest_monsterking",
+            "offset": 18,
+            "size": 7,
+            "value": 63
+        },
+        {
+            "flag": "O3:quest_baronbasement",
+            "offset": 18,
+            "size": 7,
+            "value": 64
+        },
+        {
+            "flag": "O3:quest_giant",
+            "offset": 18,
+            "size": 7,
+            "value": 65
+        },
+        {
+            "flag": "O3:quest_cavebahamut",
+            "offset": 18,
+            "size": 7,
+            "value": 66
+        },
+        {
+            "flag": "O3:quest_murasamealtar",
+            "offset": 18,
+            "size": 7,
+            "value": 67
+        },
+        {
+            "flag": "O3:quest_crystalaltar",
+            "offset": 18,
+            "size": 7,
+            "value": 68
+        },
+        {
+            "flag": "O3:quest_whitealtar",
+            "offset": 18,
+            "size": 7,
+            "value": 69
+        },
+        {
+            "flag": "O3:quest_ribbonaltar",
+            "offset": 18,
+            "size": 7,
+            "value": 70
+        },
+        {
+            "flag": "O3:quest_masamunealtar",
+            "offset": 18,
+            "size": 7,
+            "value": 71
+        },
+        {
+            "flag": "O3:quest_burnmist",
+            "offset": 18,
+            "size": 7,
+            "value": 72
+        },
+        {
+            "flag": "O3:quest_curefever",
+            "offset": 18,
+            "size": 7,
+            "value": 73
+        },
+        {
+            "flag": "O3:quest_unlocksewer",
+            "offset": 18,
+            "size": 7,
+            "value": 74
+        },
+        {
+            "flag": "O3:quest_music",
+            "offset": 18,
+            "size": 7,
+            "value": 75
+        },
+        {
+            "flag": "O3:quest_toroiatreasury",
+            "offset": 18,
+            "size": 7,
+            "value": 76
+        },
+        {
+            "flag": "O3:quest_magma",
+            "offset": 18,
+            "size": 7,
+            "value": 77
+        },
+        {
+            "flag": "O3:quest_supercannon",
+            "offset": 18,
+            "size": 7,
+            "value": 78
+        },
+        {
+            "flag": "O3:quest_unlocksealedcave",
+            "offset": 18,
+            "size": 7,
+            "value": 79
+        },
+        {
+            "flag": "O3:quest_bigwhale",
+            "offset": 18,
+            "size": 7,
+            "value": 80
+        },
+        {
+            "flag": "O3:quest_traderat",
+            "offset": 18,
+            "size": 7,
+            "value": 81
+        },
+        {
+            "flag": "O3:quest_forge",
+            "offset": 18,
+            "size": 7,
+            "value": 82
+        },
+        {
+            "flag": "O3:quest_wakeyang",
+            "offset": 18,
+            "size": 7,
+            "value": 83
+        },
+        {
+            "flag": "O3:quest_tradepan",
+            "offset": 18,
+            "size": 7,
+            "value": 84
+        },
+        {
+            "flag": "O3:quest_tradepink",
+            "offset": 18,
+            "size": 7,
+            "value": 85
+        },
+        {
+            "flag": "O3:quest_pass",
+            "offset": 18,
+            "size": 7,
+            "value": 86
+        },
+        {
+            "flag": "O4:char_cecil",
+            "offset": 25,
+            "size": 7,
+            "value": 1
+        },
+        {
+            "flag": "O4:char_kain",
+            "offset": 25,
+            "size": 7,
+            "value": 2
+        },
+        {
+            "flag": "O4:char_rydia",
+            "offset": 25,
+            "size": 7,
+            "value": 3
+        },
+        {
+            "flag": "O4:char_tellah",
+            "offset": 25,
+            "size": 7,
+            "value": 4
+        },
+        {
+            "flag": "O4:char_edward",
+            "offset": 25,
+            "size": 7,
+            "value": 5
+        },
+        {
+            "flag": "O4:char_rosa",
+            "offset": 25,
+            "size": 7,
+            "value": 6
+        },
+        {
+            "flag": "O4:char_yang",
+            "offset": 25,
+            "size": 7,
+            "value": 7
+        },
+        {
+            "flag": "O4:char_palom",
+            "offset": 25,
+            "size": 7,
+            "value": 8
+        },
+        {
+            "flag": "O4:char_porom",
+            "offset": 25,
+            "size": 7,
+            "value": 9
+        },
+        {
+            "flag": "O4:char_cid",
+            "offset": 25,
+            "size": 7,
+            "value": 10
+        },
+        {
+            "flag": "O4:char_edge",
+            "offset": 25,
+            "size": 7,
+            "value": 11
+        },
+        {
+            "flag": "O4:char_fusoya",
+            "offset": 25,
+            "size": 7,
+            "value": 12
+        },
+        {
+            "flag": "O4:boss_dmist",
+            "offset": 25,
+            "size": 7,
+            "value": 13
+        },
+        {
+            "flag": "O4:boss_officer",
+            "offset": 25,
+            "size": 7,
+            "value": 14
+        },
+        {
+            "flag": "O4:boss_octomamm",
+            "offset": 25,
+            "size": 7,
+            "value": 15
+        },
+        {
+            "flag": "O4:boss_antlion",
+            "offset": 25,
+            "size": 7,
+            "value": 16
+        },
+        {
+            "flag": "O4:boss_waterhag",
+            "offset": 25,
+            "size": 7,
+            "value": 17
+        },
+        {
+            "flag": "O4:boss_mombomb",
+            "offset": 25,
+            "size": 7,
+            "value": 18
+        },
+        {
+            "flag": "O4:boss_fabulgauntlet",
+            "offset": 25,
+            "size": 7,
+            "value": 19
+        },
+        {
+            "flag": "O4:boss_milon",
+            "offset": 25,
+            "size": 7,
+            "value": 20
+        },
+        {
+            "flag": "O4:boss_milonz",
+            "offset": 25,
+            "size": 7,
+            "value": 21
+        },
+        {
+            "flag": "O4:boss_mirrorcecil",
+            "offset": 25,
+            "size": 7,
+            "value": 22
+        },
+        {
+            "flag": "O4:boss_guard",
+            "offset": 25,
+            "size": 7,
+            "value": 23
+        },
+        {
+            "flag": "O4:boss_karate",
+            "offset": 25,
+            "size": 7,
+            "value": 24
+        },
+        {
+            "flag": "O4:boss_baigan",
+            "offset": 25,
+            "size": 7,
+            "value": 25
+        },
+        {
+            "flag": "O4:boss_kainazzo",
+            "offset": 25,
+            "size": 7,
+            "value": 26
+        },
+        {
+            "flag": "O4:boss_darkelf",
+            "offset": 25,
+            "size": 7,
+            "value": 27
+        },
+        {
+            "flag": "O4:boss_magus",
+            "offset": 25,
+            "size": 7,
+            "value": 28
+        },
+        {
+            "flag": "O4:boss_valvalis",
+            "offset": 25,
+            "size": 7,
+            "value": 29
+        },
+        {
+            "flag": "O4:boss_calbrena",
+            "offset": 25,
+            "size": 7,
+            "value": 30
+        },
+        {
+            "flag": "O4:boss_golbez",
+            "offset": 25,
+            "size": 7,
+            "value": 31
+        },
+        {
+            "flag": "O4:boss_lugae",
+            "offset": 25,
+            "size": 7,
+            "value": 32
+        },
+        {
+            "flag": "O4:boss_darkimp",
+            "offset": 25,
+            "size": 7,
+            "value": 33
+        },
+        {
+            "flag": "O4:boss_kingqueen",
+            "offset": 25,
+            "size": 7,
+            "value": 34
+        },
+        {
+            "flag": "O4:boss_rubicant",
+            "offset": 25,
+            "size": 7,
+            "value": 35
+        },
+        {
+            "flag": "O4:boss_evilwall",
+            "offset": 25,
+            "size": 7,
+            "value": 36
+        },
+        {
+            "flag": "O4:boss_asura",
+            "offset": 25,
+            "size": 7,
+            "value": 37
+        },
+        {
+            "flag": "O4:boss_leviatan",
+            "offset": 25,
+            "size": 7,
+            "value": 38
+        },
+        {
+            "flag": "O4:boss_odin",
+            "offset": 25,
+            "size": 7,
+            "value": 39
+        },
+        {
+            "flag": "O4:boss_bahamut",
+            "offset": 25,
+            "size": 7,
+            "value": 40
+        },
+        {
+            "flag": "O4:boss_elements",
+            "offset": 25,
+            "size": 7,
+            "value": 41
+        },
+        {
+            "flag": "O4:boss_cpu",
+            "offset": 25,
+            "size": 7,
+            "value": 42
+        },
+        {
+            "flag": "O4:boss_paledim",
+            "offset": 25,
+            "size": 7,
+            "value": 43
+        },
+        {
+            "flag": "O4:boss_wyvern",
+            "offset": 25,
+            "size": 7,
+            "value": 44
+        },
+        {
+            "flag": "O4:boss_plague",
+            "offset": 25,
+            "size": 7,
+            "value": 45
+        },
+        {
+            "flag": "O4:boss_dlunar",
+            "offset": 25,
+            "size": 7,
+            "value": 46
+        },
+        {
+            "flag": "O4:boss_ogopogo",
+            "offset": 25,
+            "size": 7,
+            "value": 47
+        },
+        {
+            "flag": "O4:quest_mistcave",
+            "offset": 25,
+            "size": 7,
+            "value": 48
+        },
+        {
+            "flag": "O4:quest_waterfall",
+            "offset": 25,
+            "size": 7,
+            "value": 49
+        },
+        {
+            "flag": "O4:quest_antlionnest",
+            "offset": 25,
+            "size": 7,
+            "value": 50
+        },
+        {
+            "flag": "O4:quest_hobs",
+            "offset": 25,
+            "size": 7,
+            "value": 51
+        },
+        {
+            "flag": "O4:quest_fabul",
+            "offset": 25,
+            "size": 7,
+            "value": 52
+        },
+        {
+            "flag": "O4:quest_ordeals",
+            "offset": 25,
+            "size": 7,
+            "value": 53
+        },
+        {
+            "flag": "O4:quest_baroninn",
+            "offset": 25,
+            "size": 7,
+            "value": 54
+        },
+        {
+            "flag": "O4:quest_baroncastle",
+            "offset": 25,
+            "size": 7,
+            "value": 55
+        },
+        {
+            "flag": "O4:quest_magnes",
+            "offset": 25,
+            "size": 7,
+            "value": 56
+        },
+        {
+            "flag": "O4:quest_zot",
+            "offset": 25,
+            "size": 7,
+            "value": 57
+        },
+        {
+            "flag": "O4:quest_dwarfcastle",
+            "offset": 25,
+            "size": 7,
+            "value": 58
+        },
+        {
+            "flag": "O4:quest_lowerbabil",
+            "offset": 25,
+            "size": 7,
+            "value": 59
+        },
+        {
+            "flag": "O4:quest_falcon",
+            "offset": 25,
+            "size": 7,
+            "value": 60
+        },
+        {
+            "flag": "O4:quest_sealedcave",
+            "offset": 25,
+            "size": 7,
+            "value": 61
+        },
+        {
+            "flag": "O4:quest_monsterqueen",
+            "offset": 25,
+            "size": 7,
+            "value": 62
+        },
+        {
+            "flag": "O4:quest_monsterking",
+            "offset": 25,
+            "size": 7,
+            "value": 63
+        },
+        {
+            "flag": "O4:quest_baronbasement",
+            "offset": 25,
+            "size": 7,
+            "value": 64
+        },
+        {
+            "flag": "O4:quest_giant",
+            "offset": 25,
+            "size": 7,
+            "value": 65
+        },
+        {
+            "flag": "O4:quest_cavebahamut",
+            "offset": 25,
+            "size": 7,
+            "value": 66
+        },
+        {
+            "flag": "O4:quest_murasamealtar",
+            "offset": 25,
+            "size": 7,
+            "value": 67
+        },
+        {
+            "flag": "O4:quest_crystalaltar",
+            "offset": 25,
+            "size": 7,
+            "value": 68
+        },
+        {
+            "flag": "O4:quest_whitealtar",
+            "offset": 25,
+            "size": 7,
+            "value": 69
+        },
+        {
+            "flag": "O4:quest_ribbonaltar",
+            "offset": 25,
+            "size": 7,
+            "value": 70
+        },
+        {
+            "flag": "O4:quest_masamunealtar",
+            "offset": 25,
+            "size": 7,
+            "value": 71
+        },
+        {
+            "flag": "O4:quest_burnmist",
+            "offset": 25,
+            "size": 7,
+            "value": 72
+        },
+        {
+            "flag": "O4:quest_curefever",
+            "offset": 25,
+            "size": 7,
+            "value": 73
+        },
+        {
+            "flag": "O4:quest_unlocksewer",
+            "offset": 25,
+            "size": 7,
+            "value": 74
+        },
+        {
+            "flag": "O4:quest_music",
+            "offset": 25,
+            "size": 7,
+            "value": 75
+        },
+        {
+            "flag": "O4:quest_toroiatreasury",
+            "offset": 25,
+            "size": 7,
+            "value": 76
+        },
+        {
+            "flag": "O4:quest_magma",
+            "offset": 25,
+            "size": 7,
+            "value": 77
+        },
+        {
+            "flag": "O4:quest_supercannon",
+            "offset": 25,
+            "size": 7,
+            "value": 78
+        },
+        {
+            "flag": "O4:quest_unlocksealedcave",
+            "offset": 25,
+            "size": 7,
+            "value": 79
+        },
+        {
+            "flag": "O4:quest_bigwhale",
+            "offset": 25,
+            "size": 7,
+            "value": 80
+        },
+        {
+            "flag": "O4:quest_traderat",
+            "offset": 25,
+            "size": 7,
+            "value": 81
+        },
+        {
+            "flag": "O4:quest_forge",
+            "offset": 25,
+            "size": 7,
+            "value": 82
+        },
+        {
+            "flag": "O4:quest_wakeyang",
+            "offset": 25,
+            "size": 7,
+            "value": 83
+        },
+        {
+            "flag": "O4:quest_tradepan",
+            "offset": 25,
+            "size": 7,
+            "value": 84
+        },
+        {
+            "flag": "O4:quest_tradepink",
+            "offset": 25,
+            "size": 7,
+            "value": 85
+        },
+        {
+            "flag": "O4:quest_pass",
+            "offset": 25,
+            "size": 7,
+            "value": 86
+        },
+        {
+            "flag": "O5:char_cecil",
+            "offset": 32,
+            "size": 7,
+            "value": 1
+        },
+        {
+            "flag": "O5:char_kain",
+            "offset": 32,
+            "size": 7,
+            "value": 2
+        },
+        {
+            "flag": "O5:char_rydia",
+            "offset": 32,
+            "size": 7,
+            "value": 3
+        },
+        {
+            "flag": "O5:char_tellah",
+            "offset": 32,
+            "size": 7,
+            "value": 4
+        },
+        {
+            "flag": "O5:char_edward",
+            "offset": 32,
+            "size": 7,
+            "value": 5
+        },
+        {
+            "flag": "O5:char_rosa",
+            "offset": 32,
+            "size": 7,
+            "value": 6
+        },
+        {
+            "flag": "O5:char_yang",
+            "offset": 32,
+            "size": 7,
+            "value": 7
+        },
+        {
+            "flag": "O5:char_palom",
+            "offset": 32,
+            "size": 7,
+            "value": 8
+        },
+        {
+            "flag": "O5:char_porom",
+            "offset": 32,
+            "size": 7,
+            "value": 9
+        },
+        {
+            "flag": "O5:char_cid",
+            "offset": 32,
+            "size": 7,
+            "value": 10
+        },
+        {
+            "flag": "O5:char_edge",
+            "offset": 32,
+            "size": 7,
+            "value": 11
+        },
+        {
+            "flag": "O5:char_fusoya",
+            "offset": 32,
+            "size": 7,
+            "value": 12
+        },
+        {
+            "flag": "O5:boss_dmist",
+            "offset": 32,
+            "size": 7,
+            "value": 13
+        },
+        {
+            "flag": "O5:boss_officer",
+            "offset": 32,
+            "size": 7,
+            "value": 14
+        },
+        {
+            "flag": "O5:boss_octomamm",
+            "offset": 32,
+            "size": 7,
+            "value": 15
+        },
+        {
+            "flag": "O5:boss_antlion",
+            "offset": 32,
+            "size": 7,
+            "value": 16
+        },
+        {
+            "flag": "O5:boss_waterhag",
+            "offset": 32,
+            "size": 7,
+            "value": 17
+        },
+        {
+            "flag": "O5:boss_mombomb",
+            "offset": 32,
+            "size": 7,
+            "value": 18
+        },
+        {
+            "flag": "O5:boss_fabulgauntlet",
+            "offset": 32,
+            "size": 7,
+            "value": 19
+        },
+        {
+            "flag": "O5:boss_milon",
+            "offset": 32,
+            "size": 7,
+            "value": 20
+        },
+        {
+            "flag": "O5:boss_milonz",
+            "offset": 32,
+            "size": 7,
+            "value": 21
+        },
+        {
+            "flag": "O5:boss_mirrorcecil",
+            "offset": 32,
+            "size": 7,
+            "value": 22
+        },
+        {
+            "flag": "O5:boss_guard",
+            "offset": 32,
+            "size": 7,
+            "value": 23
+        },
+        {
+            "flag": "O5:boss_karate",
+            "offset": 32,
+            "size": 7,
+            "value": 24
+        },
+        {
+            "flag": "O5:boss_baigan",
+            "offset": 32,
+            "size": 7,
+            "value": 25
+        },
+        {
+            "flag": "O5:boss_kainazzo",
+            "offset": 32,
+            "size": 7,
+            "value": 26
+        },
+        {
+            "flag": "O5:boss_darkelf",
+            "offset": 32,
+            "size": 7,
+            "value": 27
+        },
+        {
+            "flag": "O5:boss_magus",
+            "offset": 32,
+            "size": 7,
+            "value": 28
+        },
+        {
+            "flag": "O5:boss_valvalis",
+            "offset": 32,
+            "size": 7,
+            "value": 29
+        },
+        {
+            "flag": "O5:boss_calbrena",
+            "offset": 32,
+            "size": 7,
+            "value": 30
+        },
+        {
+            "flag": "O5:boss_golbez",
+            "offset": 32,
+            "size": 7,
+            "value": 31
+        },
+        {
+            "flag": "O5:boss_lugae",
+            "offset": 32,
+            "size": 7,
+            "value": 32
+        },
+        {
+            "flag": "O5:boss_darkimp",
+            "offset": 32,
+            "size": 7,
+            "value": 33
+        },
+        {
+            "flag": "O5:boss_kingqueen",
+            "offset": 32,
+            "size": 7,
+            "value": 34
+        },
+        {
+            "flag": "O5:boss_rubicant",
+            "offset": 32,
+            "size": 7,
+            "value": 35
+        },
+        {
+            "flag": "O5:boss_evilwall",
+            "offset": 32,
+            "size": 7,
+            "value": 36
+        },
+        {
+            "flag": "O5:boss_asura",
+            "offset": 32,
+            "size": 7,
+            "value": 37
+        },
+        {
+            "flag": "O5:boss_leviatan",
+            "offset": 32,
+            "size": 7,
+            "value": 38
+        },
+        {
+            "flag": "O5:boss_odin",
+            "offset": 32,
+            "size": 7,
+            "value": 39
+        },
+        {
+            "flag": "O5:boss_bahamut",
+            "offset": 32,
+            "size": 7,
+            "value": 40
+        },
+        {
+            "flag": "O5:boss_elements",
+            "offset": 32,
+            "size": 7,
+            "value": 41
+        },
+        {
+            "flag": "O5:boss_cpu",
+            "offset": 32,
+            "size": 7,
+            "value": 42
+        },
+        {
+            "flag": "O5:boss_paledim",
+            "offset": 32,
+            "size": 7,
+            "value": 43
+        },
+        {
+            "flag": "O5:boss_wyvern",
+            "offset": 32,
+            "size": 7,
+            "value": 44
+        },
+        {
+            "flag": "O5:boss_plague",
+            "offset": 32,
+            "size": 7,
+            "value": 45
+        },
+        {
+            "flag": "O5:boss_dlunar",
+            "offset": 32,
+            "size": 7,
+            "value": 46
+        },
+        {
+            "flag": "O5:boss_ogopogo",
+            "offset": 32,
+            "size": 7,
+            "value": 47
+        },
+        {
+            "flag": "O5:quest_mistcave",
+            "offset": 32,
+            "size": 7,
+            "value": 48
+        },
+        {
+            "flag": "O5:quest_waterfall",
+            "offset": 32,
+            "size": 7,
+            "value": 49
+        },
+        {
+            "flag": "O5:quest_antlionnest",
+            "offset": 32,
+            "size": 7,
+            "value": 50
+        },
+        {
+            "flag": "O5:quest_hobs",
+            "offset": 32,
+            "size": 7,
+            "value": 51
+        },
+        {
+            "flag": "O5:quest_fabul",
+            "offset": 32,
+            "size": 7,
+            "value": 52
+        },
+        {
+            "flag": "O5:quest_ordeals",
+            "offset": 32,
+            "size": 7,
+            "value": 53
+        },
+        {
+            "flag": "O5:quest_baroninn",
+            "offset": 32,
+            "size": 7,
+            "value": 54
+        },
+        {
+            "flag": "O5:quest_baroncastle",
+            "offset": 32,
+            "size": 7,
+            "value": 55
+        },
+        {
+            "flag": "O5:quest_magnes",
+            "offset": 32,
+            "size": 7,
+            "value": 56
+        },
+        {
+            "flag": "O5:quest_zot",
+            "offset": 32,
+            "size": 7,
+            "value": 57
+        },
+        {
+            "flag": "O5:quest_dwarfcastle",
+            "offset": 32,
+            "size": 7,
+            "value": 58
+        },
+        {
+            "flag": "O5:quest_lowerbabil",
+            "offset": 32,
+            "size": 7,
+            "value": 59
+        },
+        {
+            "flag": "O5:quest_falcon",
+            "offset": 32,
+            "size": 7,
+            "value": 60
+        },
+        {
+            "flag": "O5:quest_sealedcave",
+            "offset": 32,
+            "size": 7,
+            "value": 61
+        },
+        {
+            "flag": "O5:quest_monsterqueen",
+            "offset": 32,
+            "size": 7,
+            "value": 62
+        },
+        {
+            "flag": "O5:quest_monsterking",
+            "offset": 32,
+            "size": 7,
+            "value": 63
+        },
+        {
+            "flag": "O5:quest_baronbasement",
+            "offset": 32,
+            "size": 7,
+            "value": 64
+        },
+        {
+            "flag": "O5:quest_giant",
+            "offset": 32,
+            "size": 7,
+            "value": 65
+        },
+        {
+            "flag": "O5:quest_cavebahamut",
+            "offset": 32,
+            "size": 7,
+            "value": 66
+        },
+        {
+            "flag": "O5:quest_murasamealtar",
+            "offset": 32,
+            "size": 7,
+            "value": 67
+        },
+        {
+            "flag": "O5:quest_crystalaltar",
+            "offset": 32,
+            "size": 7,
+            "value": 68
+        },
+        {
+            "flag": "O5:quest_whitealtar",
+            "offset": 32,
+            "size": 7,
+            "value": 69
+        },
+        {
+            "flag": "O5:quest_ribbonaltar",
+            "offset": 32,
+            "size": 7,
+            "value": 70
+        },
+        {
+            "flag": "O5:quest_masamunealtar",
+            "offset": 32,
+            "size": 7,
+            "value": 71
+        },
+        {
+            "flag": "O5:quest_burnmist",
+            "offset": 32,
+            "size": 7,
+            "value": 72
+        },
+        {
+            "flag": "O5:quest_curefever",
+            "offset": 32,
+            "size": 7,
+            "value": 73
+        },
+        {
+            "flag": "O5:quest_unlocksewer",
+            "offset": 32,
+            "size": 7,
+            "value": 74
+        },
+        {
+            "flag": "O5:quest_music",
+            "offset": 32,
+            "size": 7,
+            "value": 75
+        },
+        {
+            "flag": "O5:quest_toroiatreasury",
+            "offset": 32,
+            "size": 7,
+            "value": 76
+        },
+        {
+            "flag": "O5:quest_magma",
+            "offset": 32,
+            "size": 7,
+            "value": 77
+        },
+        {
+            "flag": "O5:quest_supercannon",
+            "offset": 32,
+            "size": 7,
+            "value": 78
+        },
+        {
+            "flag": "O5:quest_unlocksealedcave",
+            "offset": 32,
+            "size": 7,
+            "value": 79
+        },
+        {
+            "flag": "O5:quest_bigwhale",
+            "offset": 32,
+            "size": 7,
+            "value": 80
+        },
+        {
+            "flag": "O5:quest_traderat",
+            "offset": 32,
+            "size": 7,
+            "value": 81
+        },
+        {
+            "flag": "O5:quest_forge",
+            "offset": 32,
+            "size": 7,
+            "value": 82
+        },
+        {
+            "flag": "O5:quest_wakeyang",
+            "offset": 32,
+            "size": 7,
+            "value": 83
+        },
+        {
+            "flag": "O5:quest_tradepan",
+            "offset": 32,
+            "size": 7,
+            "value": 84
+        },
+        {
+            "flag": "O5:quest_tradepink",
+            "offset": 32,
+            "size": 7,
+            "value": 85
+        },
+        {
+            "flag": "O5:quest_pass",
+            "offset": 32,
+            "size": 7,
+            "value": 86
+        },
+        {
+            "flag": "O6:char_cecil",
+            "offset": 39,
+            "size": 7,
+            "value": 1
+        },
+        {
+            "flag": "O6:char_kain",
+            "offset": 39,
+            "size": 7,
+            "value": 2
+        },
+        {
+            "flag": "O6:char_rydia",
+            "offset": 39,
+            "size": 7,
+            "value": 3
+        },
+        {
+            "flag": "O6:char_tellah",
+            "offset": 39,
+            "size": 7,
+            "value": 4
+        },
+        {
+            "flag": "O6:char_edward",
+            "offset": 39,
+            "size": 7,
+            "value": 5
+        },
+        {
+            "flag": "O6:char_rosa",
+            "offset": 39,
+            "size": 7,
+            "value": 6
+        },
+        {
+            "flag": "O6:char_yang",
+            "offset": 39,
+            "size": 7,
+            "value": 7
+        },
+        {
+            "flag": "O6:char_palom",
+            "offset": 39,
+            "size": 7,
+            "value": 8
+        },
+        {
+            "flag": "O6:char_porom",
+            "offset": 39,
+            "size": 7,
+            "value": 9
+        },
+        {
+            "flag": "O6:char_cid",
+            "offset": 39,
+            "size": 7,
+            "value": 10
+        },
+        {
+            "flag": "O6:char_edge",
+            "offset": 39,
+            "size": 7,
+            "value": 11
+        },
+        {
+            "flag": "O6:char_fusoya",
+            "offset": 39,
+            "size": 7,
+            "value": 12
+        },
+        {
+            "flag": "O6:boss_dmist",
+            "offset": 39,
+            "size": 7,
+            "value": 13
+        },
+        {
+            "flag": "O6:boss_officer",
+            "offset": 39,
+            "size": 7,
+            "value": 14
+        },
+        {
+            "flag": "O6:boss_octomamm",
+            "offset": 39,
+            "size": 7,
+            "value": 15
+        },
+        {
+            "flag": "O6:boss_antlion",
+            "offset": 39,
+            "size": 7,
+            "value": 16
+        },
+        {
+            "flag": "O6:boss_waterhag",
+            "offset": 39,
+            "size": 7,
+            "value": 17
+        },
+        {
+            "flag": "O6:boss_mombomb",
+            "offset": 39,
+            "size": 7,
+            "value": 18
+        },
+        {
+            "flag": "O6:boss_fabulgauntlet",
+            "offset": 39,
+            "size": 7,
+            "value": 19
+        },
+        {
+            "flag": "O6:boss_milon",
+            "offset": 39,
+            "size": 7,
+            "value": 20
+        },
+        {
+            "flag": "O6:boss_milonz",
+            "offset": 39,
+            "size": 7,
+            "value": 21
+        },
+        {
+            "flag": "O6:boss_mirrorcecil",
+            "offset": 39,
+            "size": 7,
+            "value": 22
+        },
+        {
+            "flag": "O6:boss_guard",
+            "offset": 39,
+            "size": 7,
+            "value": 23
+        },
+        {
+            "flag": "O6:boss_karate",
+            "offset": 39,
+            "size": 7,
+            "value": 24
+        },
+        {
+            "flag": "O6:boss_baigan",
+            "offset": 39,
+            "size": 7,
+            "value": 25
+        },
+        {
+            "flag": "O6:boss_kainazzo",
+            "offset": 39,
+            "size": 7,
+            "value": 26
+        },
+        {
+            "flag": "O6:boss_darkelf",
+            "offset": 39,
+            "size": 7,
+            "value": 27
+        },
+        {
+            "flag": "O6:boss_magus",
+            "offset": 39,
+            "size": 7,
+            "value": 28
+        },
+        {
+            "flag": "O6:boss_valvalis",
+            "offset": 39,
+            "size": 7,
+            "value": 29
+        },
+        {
+            "flag": "O6:boss_calbrena",
+            "offset": 39,
+            "size": 7,
+            "value": 30
+        },
+        {
+            "flag": "O6:boss_golbez",
+            "offset": 39,
+            "size": 7,
+            "value": 31
+        },
+        {
+            "flag": "O6:boss_lugae",
+            "offset": 39,
+            "size": 7,
+            "value": 32
+        },
+        {
+            "flag": "O6:boss_darkimp",
+            "offset": 39,
+            "size": 7,
+            "value": 33
+        },
+        {
+            "flag": "O6:boss_kingqueen",
+            "offset": 39,
+            "size": 7,
+            "value": 34
+        },
+        {
+            "flag": "O6:boss_rubicant",
+            "offset": 39,
+            "size": 7,
+            "value": 35
+        },
+        {
+            "flag": "O6:boss_evilwall",
+            "offset": 39,
+            "size": 7,
+            "value": 36
+        },
+        {
+            "flag": "O6:boss_asura",
+            "offset": 39,
+            "size": 7,
+            "value": 37
+        },
+        {
+            "flag": "O6:boss_leviatan",
+            "offset": 39,
+            "size": 7,
+            "value": 38
+        },
+        {
+            "flag": "O6:boss_odin",
+            "offset": 39,
+            "size": 7,
+            "value": 39
+        },
+        {
+            "flag": "O6:boss_bahamut",
+            "offset": 39,
+            "size": 7,
+            "value": 40
+        },
+        {
+            "flag": "O6:boss_elements",
+            "offset": 39,
+            "size": 7,
+            "value": 41
+        },
+        {
+            "flag": "O6:boss_cpu",
+            "offset": 39,
+            "size": 7,
+            "value": 42
+        },
+        {
+            "flag": "O6:boss_paledim",
+            "offset": 39,
+            "size": 7,
+            "value": 43
+        },
+        {
+            "flag": "O6:boss_wyvern",
+            "offset": 39,
+            "size": 7,
+            "value": 44
+        },
+        {
+            "flag": "O6:boss_plague",
+            "offset": 39,
+            "size": 7,
+            "value": 45
+        },
+        {
+            "flag": "O6:boss_dlunar",
+            "offset": 39,
+            "size": 7,
+            "value": 46
+        },
+        {
+            "flag": "O6:boss_ogopogo",
+            "offset": 39,
+            "size": 7,
+            "value": 47
+        },
+        {
+            "flag": "O6:quest_mistcave",
+            "offset": 39,
+            "size": 7,
+            "value": 48
+        },
+        {
+            "flag": "O6:quest_waterfall",
+            "offset": 39,
+            "size": 7,
+            "value": 49
+        },
+        {
+            "flag": "O6:quest_antlionnest",
+            "offset": 39,
+            "size": 7,
+            "value": 50
+        },
+        {
+            "flag": "O6:quest_hobs",
+            "offset": 39,
+            "size": 7,
+            "value": 51
+        },
+        {
+            "flag": "O6:quest_fabul",
+            "offset": 39,
+            "size": 7,
+            "value": 52
+        },
+        {
+            "flag": "O6:quest_ordeals",
+            "offset": 39,
+            "size": 7,
+            "value": 53
+        },
+        {
+            "flag": "O6:quest_baroninn",
+            "offset": 39,
+            "size": 7,
+            "value": 54
+        },
+        {
+            "flag": "O6:quest_baroncastle",
+            "offset": 39,
+            "size": 7,
+            "value": 55
+        },
+        {
+            "flag": "O6:quest_magnes",
+            "offset": 39,
+            "size": 7,
+            "value": 56
+        },
+        {
+            "flag": "O6:quest_zot",
+            "offset": 39,
+            "size": 7,
+            "value": 57
+        },
+        {
+            "flag": "O6:quest_dwarfcastle",
+            "offset": 39,
+            "size": 7,
+            "value": 58
+        },
+        {
+            "flag": "O6:quest_lowerbabil",
+            "offset": 39,
+            "size": 7,
+            "value": 59
+        },
+        {
+            "flag": "O6:quest_falcon",
+            "offset": 39,
+            "size": 7,
+            "value": 60
+        },
+        {
+            "flag": "O6:quest_sealedcave",
+            "offset": 39,
+            "size": 7,
+            "value": 61
+        },
+        {
+            "flag": "O6:quest_monsterqueen",
+            "offset": 39,
+            "size": 7,
+            "value": 62
+        },
+        {
+            "flag": "O6:quest_monsterking",
+            "offset": 39,
+            "size": 7,
+            "value": 63
+        },
+        {
+            "flag": "O6:quest_baronbasement",
+            "offset": 39,
+            "size": 7,
+            "value": 64
+        },
+        {
+            "flag": "O6:quest_giant",
+            "offset": 39,
+            "size": 7,
+            "value": 65
+        },
+        {
+            "flag": "O6:quest_cavebahamut",
+            "offset": 39,
+            "size": 7,
+            "value": 66
+        },
+        {
+            "flag": "O6:quest_murasamealtar",
+            "offset": 39,
+            "size": 7,
+            "value": 67
+        },
+        {
+            "flag": "O6:quest_crystalaltar",
+            "offset": 39,
+            "size": 7,
+            "value": 68
+        },
+        {
+            "flag": "O6:quest_whitealtar",
+            "offset": 39,
+            "size": 7,
+            "value": 69
+        },
+        {
+            "flag": "O6:quest_ribbonaltar",
+            "offset": 39,
+            "size": 7,
+            "value": 70
+        },
+        {
+            "flag": "O6:quest_masamunealtar",
+            "offset": 39,
+            "size": 7,
+            "value": 71
+        },
+        {
+            "flag": "O6:quest_burnmist",
+            "offset": 39,
+            "size": 7,
+            "value": 72
+        },
+        {
+            "flag": "O6:quest_curefever",
+            "offset": 39,
+            "size": 7,
+            "value": 73
+        },
+        {
+            "flag": "O6:quest_unlocksewer",
+            "offset": 39,
+            "size": 7,
+            "value": 74
+        },
+        {
+            "flag": "O6:quest_music",
+            "offset": 39,
+            "size": 7,
+            "value": 75
+        },
+        {
+            "flag": "O6:quest_toroiatreasury",
+            "offset": 39,
+            "size": 7,
+            "value": 76
+        },
+        {
+            "flag": "O6:quest_magma",
+            "offset": 39,
+            "size": 7,
+            "value": 77
+        },
+        {
+            "flag": "O6:quest_supercannon",
+            "offset": 39,
+            "size": 7,
+            "value": 78
+        },
+        {
+            "flag": "O6:quest_unlocksealedcave",
+            "offset": 39,
+            "size": 7,
+            "value": 79
+        },
+        {
+            "flag": "O6:quest_bigwhale",
+            "offset": 39,
+            "size": 7,
+            "value": 80
+        },
+        {
+            "flag": "O6:quest_traderat",
+            "offset": 39,
+            "size": 7,
+            "value": 81
+        },
+        {
+            "flag": "O6:quest_forge",
+            "offset": 39,
+            "size": 7,
+            "value": 82
+        },
+        {
+            "flag": "O6:quest_wakeyang",
+            "offset": 39,
+            "size": 7,
+            "value": 83
+        },
+        {
+            "flag": "O6:quest_tradepan",
+            "offset": 39,
+            "size": 7,
+            "value": 84
+        },
+        {
+            "flag": "O6:quest_tradepink",
+            "offset": 39,
+            "size": 7,
+            "value": 85
+        },
+        {
+            "flag": "O6:quest_pass",
+            "offset": 39,
+            "size": 7,
+            "value": 86
+        },
+        {
+            "flag": "O7:char_cecil",
+            "offset": 46,
+            "size": 7,
+            "value": 1
+        },
+        {
+            "flag": "O7:char_kain",
+            "offset": 46,
+            "size": 7,
+            "value": 2
+        },
+        {
+            "flag": "O7:char_rydia",
+            "offset": 46,
+            "size": 7,
+            "value": 3
+        },
+        {
+            "flag": "O7:char_tellah",
+            "offset": 46,
+            "size": 7,
+            "value": 4
+        },
+        {
+            "flag": "O7:char_edward",
+            "offset": 46,
+            "size": 7,
+            "value": 5
+        },
+        {
+            "flag": "O7:char_rosa",
+            "offset": 46,
+            "size": 7,
+            "value": 6
+        },
+        {
+            "flag": "O7:char_yang",
+            "offset": 46,
+            "size": 7,
+            "value": 7
+        },
+        {
+            "flag": "O7:char_palom",
+            "offset": 46,
+            "size": 7,
+            "value": 8
+        },
+        {
+            "flag": "O7:char_porom",
+            "offset": 46,
+            "size": 7,
+            "value": 9
+        },
+        {
+            "flag": "O7:char_cid",
+            "offset": 46,
+            "size": 7,
+            "value": 10
+        },
+        {
+            "flag": "O7:char_edge",
+            "offset": 46,
+            "size": 7,
+            "value": 11
+        },
+        {
+            "flag": "O7:char_fusoya",
+            "offset": 46,
+            "size": 7,
+            "value": 12
+        },
+        {
+            "flag": "O7:boss_dmist",
+            "offset": 46,
+            "size": 7,
+            "value": 13
+        },
+        {
+            "flag": "O7:boss_officer",
+            "offset": 46,
+            "size": 7,
+            "value": 14
+        },
+        {
+            "flag": "O7:boss_octomamm",
+            "offset": 46,
+            "size": 7,
+            "value": 15
+        },
+        {
+            "flag": "O7:boss_antlion",
+            "offset": 46,
+            "size": 7,
+            "value": 16
+        },
+        {
+            "flag": "O7:boss_waterhag",
+            "offset": 46,
+            "size": 7,
+            "value": 17
+        },
+        {
+            "flag": "O7:boss_mombomb",
+            "offset": 46,
+            "size": 7,
+            "value": 18
+        },
+        {
+            "flag": "O7:boss_fabulgauntlet",
+            "offset": 46,
+            "size": 7,
+            "value": 19
+        },
+        {
+            "flag": "O7:boss_milon",
+            "offset": 46,
+            "size": 7,
+            "value": 20
+        },
+        {
+            "flag": "O7:boss_milonz",
+            "offset": 46,
+            "size": 7,
+            "value": 21
+        },
+        {
+            "flag": "O7:boss_mirrorcecil",
+            "offset": 46,
+            "size": 7,
+            "value": 22
+        },
+        {
+            "flag": "O7:boss_guard",
+            "offset": 46,
+            "size": 7,
+            "value": 23
+        },
+        {
+            "flag": "O7:boss_karate",
+            "offset": 46,
+            "size": 7,
+            "value": 24
+        },
+        {
+            "flag": "O7:boss_baigan",
+            "offset": 46,
+            "size": 7,
+            "value": 25
+        },
+        {
+            "flag": "O7:boss_kainazzo",
+            "offset": 46,
+            "size": 7,
+            "value": 26
+        },
+        {
+            "flag": "O7:boss_darkelf",
+            "offset": 46,
+            "size": 7,
+            "value": 27
+        },
+        {
+            "flag": "O7:boss_magus",
+            "offset": 46,
+            "size": 7,
+            "value": 28
+        },
+        {
+            "flag": "O7:boss_valvalis",
+            "offset": 46,
+            "size": 7,
+            "value": 29
+        },
+        {
+            "flag": "O7:boss_calbrena",
+            "offset": 46,
+            "size": 7,
+            "value": 30
+        },
+        {
+            "flag": "O7:boss_golbez",
+            "offset": 46,
+            "size": 7,
+            "value": 31
+        },
+        {
+            "flag": "O7:boss_lugae",
+            "offset": 46,
+            "size": 7,
+            "value": 32
+        },
+        {
+            "flag": "O7:boss_darkimp",
+            "offset": 46,
+            "size": 7,
+            "value": 33
+        },
+        {
+            "flag": "O7:boss_kingqueen",
+            "offset": 46,
+            "size": 7,
+            "value": 34
+        },
+        {
+            "flag": "O7:boss_rubicant",
+            "offset": 46,
+            "size": 7,
+            "value": 35
+        },
+        {
+            "flag": "O7:boss_evilwall",
+            "offset": 46,
+            "size": 7,
+            "value": 36
+        },
+        {
+            "flag": "O7:boss_asura",
+            "offset": 46,
+            "size": 7,
+            "value": 37
+        },
+        {
+            "flag": "O7:boss_leviatan",
+            "offset": 46,
+            "size": 7,
+            "value": 38
+        },
+        {
+            "flag": "O7:boss_odin",
+            "offset": 46,
+            "size": 7,
+            "value": 39
+        },
+        {
+            "flag": "O7:boss_bahamut",
+            "offset": 46,
+            "size": 7,
+            "value": 40
+        },
+        {
+            "flag": "O7:boss_elements",
+            "offset": 46,
+            "size": 7,
+            "value": 41
+        },
+        {
+            "flag": "O7:boss_cpu",
+            "offset": 46,
+            "size": 7,
+            "value": 42
+        },
+        {
+            "flag": "O7:boss_paledim",
+            "offset": 46,
+            "size": 7,
+            "value": 43
+        },
+        {
+            "flag": "O7:boss_wyvern",
+            "offset": 46,
+            "size": 7,
+            "value": 44
+        },
+        {
+            "flag": "O7:boss_plague",
+            "offset": 46,
+            "size": 7,
+            "value": 45
+        },
+        {
+            "flag": "O7:boss_dlunar",
+            "offset": 46,
+            "size": 7,
+            "value": 46
+        },
+        {
+            "flag": "O7:boss_ogopogo",
+            "offset": 46,
+            "size": 7,
+            "value": 47
+        },
+        {
+            "flag": "O7:quest_mistcave",
+            "offset": 46,
+            "size": 7,
+            "value": 48
+        },
+        {
+            "flag": "O7:quest_waterfall",
+            "offset": 46,
+            "size": 7,
+            "value": 49
+        },
+        {
+            "flag": "O7:quest_antlionnest",
+            "offset": 46,
+            "size": 7,
+            "value": 50
+        },
+        {
+            "flag": "O7:quest_hobs",
+            "offset": 46,
+            "size": 7,
+            "value": 51
+        },
+        {
+            "flag": "O7:quest_fabul",
+            "offset": 46,
+            "size": 7,
+            "value": 52
+        },
+        {
+            "flag": "O7:quest_ordeals",
+            "offset": 46,
+            "size": 7,
+            "value": 53
+        },
+        {
+            "flag": "O7:quest_baroninn",
+            "offset": 46,
+            "size": 7,
+            "value": 54
+        },
+        {
+            "flag": "O7:quest_baroncastle",
+            "offset": 46,
+            "size": 7,
+            "value": 55
+        },
+        {
+            "flag": "O7:quest_magnes",
+            "offset": 46,
+            "size": 7,
+            "value": 56
+        },
+        {
+            "flag": "O7:quest_zot",
+            "offset": 46,
+            "size": 7,
+            "value": 57
+        },
+        {
+            "flag": "O7:quest_dwarfcastle",
+            "offset": 46,
+            "size": 7,
+            "value": 58
+        },
+        {
+            "flag": "O7:quest_lowerbabil",
+            "offset": 46,
+            "size": 7,
+            "value": 59
+        },
+        {
+            "flag": "O7:quest_falcon",
+            "offset": 46,
+            "size": 7,
+            "value": 60
+        },
+        {
+            "flag": "O7:quest_sealedcave",
+            "offset": 46,
+            "size": 7,
+            "value": 61
+        },
+        {
+            "flag": "O7:quest_monsterqueen",
+            "offset": 46,
+            "size": 7,
+            "value": 62
+        },
+        {
+            "flag": "O7:quest_monsterking",
+            "offset": 46,
+            "size": 7,
+            "value": 63
+        },
+        {
+            "flag": "O7:quest_baronbasement",
+            "offset": 46,
+            "size": 7,
+            "value": 64
+        },
+        {
+            "flag": "O7:quest_giant",
+            "offset": 46,
+            "size": 7,
+            "value": 65
+        },
+        {
+            "flag": "O7:quest_cavebahamut",
+            "offset": 46,
+            "size": 7,
+            "value": 66
+        },
+        {
+            "flag": "O7:quest_murasamealtar",
+            "offset": 46,
+            "size": 7,
+            "value": 67
+        },
+        {
+            "flag": "O7:quest_crystalaltar",
+            "offset": 46,
+            "size": 7,
+            "value": 68
+        },
+        {
+            "flag": "O7:quest_whitealtar",
+            "offset": 46,
+            "size": 7,
+            "value": 69
+        },
+        {
+            "flag": "O7:quest_ribbonaltar",
+            "offset": 46,
+            "size": 7,
+            "value": 70
+        },
+        {
+            "flag": "O7:quest_masamunealtar",
+            "offset": 46,
+            "size": 7,
+            "value": 71
+        },
+        {
+            "flag": "O7:quest_burnmist",
+            "offset": 46,
+            "size": 7,
+            "value": 72
+        },
+        {
+            "flag": "O7:quest_curefever",
+            "offset": 46,
+            "size": 7,
+            "value": 73
+        },
+        {
+            "flag": "O7:quest_unlocksewer",
+            "offset": 46,
+            "size": 7,
+            "value": 74
+        },
+        {
+            "flag": "O7:quest_music",
+            "offset": 46,
+            "size": 7,
+            "value": 75
+        },
+        {
+            "flag": "O7:quest_toroiatreasury",
+            "offset": 46,
+            "size": 7,
+            "value": 76
+        },
+        {
+            "flag": "O7:quest_magma",
+            "offset": 46,
+            "size": 7,
+            "value": 77
+        },
+        {
+            "flag": "O7:quest_supercannon",
+            "offset": 46,
+            "size": 7,
+            "value": 78
+        },
+        {
+            "flag": "O7:quest_unlocksealedcave",
+            "offset": 46,
+            "size": 7,
+            "value": 79
+        },
+        {
+            "flag": "O7:quest_bigwhale",
+            "offset": 46,
+            "size": 7,
+            "value": 80
+        },
+        {
+            "flag": "O7:quest_traderat",
+            "offset": 46,
+            "size": 7,
+            "value": 81
+        },
+        {
+            "flag": "O7:quest_forge",
+            "offset": 46,
+            "size": 7,
+            "value": 82
+        },
+        {
+            "flag": "O7:quest_wakeyang",
+            "offset": 46,
+            "size": 7,
+            "value": 83
+        },
+        {
+            "flag": "O7:quest_tradepan",
+            "offset": 46,
+            "size": 7,
+            "value": 84
+        },
+        {
+            "flag": "O7:quest_tradepink",
+            "offset": 46,
+            "size": 7,
+            "value": 85
+        },
+        {
+            "flag": "O7:quest_pass",
+            "offset": 46,
+            "size": 7,
+            "value": 86
+        },
+        {
+            "flag": "O8:char_cecil",
+            "offset": 53,
+            "size": 7,
+            "value": 1
+        },
+        {
+            "flag": "O8:char_kain",
+            "offset": 53,
+            "size": 7,
+            "value": 2
+        },
+        {
+            "flag": "O8:char_rydia",
+            "offset": 53,
+            "size": 7,
+            "value": 3
+        },
+        {
+            "flag": "O8:char_tellah",
+            "offset": 53,
+            "size": 7,
+            "value": 4
+        },
+        {
+            "flag": "O8:char_edward",
+            "offset": 53,
+            "size": 7,
+            "value": 5
+        },
+        {
+            "flag": "O8:char_rosa",
+            "offset": 53,
+            "size": 7,
+            "value": 6
+        },
+        {
+            "flag": "O8:char_yang",
+            "offset": 53,
+            "size": 7,
+            "value": 7
+        },
+        {
+            "flag": "O8:char_palom",
+            "offset": 53,
+            "size": 7,
+            "value": 8
+        },
+        {
+            "flag": "O8:char_porom",
+            "offset": 53,
+            "size": 7,
+            "value": 9
+        },
+        {
+            "flag": "O8:char_cid",
+            "offset": 53,
+            "size": 7,
+            "value": 10
+        },
+        {
+            "flag": "O8:char_edge",
+            "offset": 53,
+            "size": 7,
+            "value": 11
+        },
+        {
+            "flag": "O8:char_fusoya",
+            "offset": 53,
+            "size": 7,
+            "value": 12
+        },
+        {
+            "flag": "O8:boss_dmist",
+            "offset": 53,
+            "size": 7,
+            "value": 13
+        },
+        {
+            "flag": "O8:boss_officer",
+            "offset": 53,
+            "size": 7,
+            "value": 14
+        },
+        {
+            "flag": "O8:boss_octomamm",
+            "offset": 53,
+            "size": 7,
+            "value": 15
+        },
+        {
+            "flag": "O8:boss_antlion",
+            "offset": 53,
+            "size": 7,
+            "value": 16
+        },
+        {
+            "flag": "O8:boss_waterhag",
+            "offset": 53,
+            "size": 7,
+            "value": 17
+        },
+        {
+            "flag": "O8:boss_mombomb",
+            "offset": 53,
+            "size": 7,
+            "value": 18
+        },
+        {
+            "flag": "O8:boss_fabulgauntlet",
+            "offset": 53,
+            "size": 7,
+            "value": 19
+        },
+        {
+            "flag": "O8:boss_milon",
+            "offset": 53,
+            "size": 7,
+            "value": 20
+        },
+        {
+            "flag": "O8:boss_milonz",
+            "offset": 53,
+            "size": 7,
+            "value": 21
+        },
+        {
+            "flag": "O8:boss_mirrorcecil",
+            "offset": 53,
+            "size": 7,
+            "value": 22
+        },
+        {
+            "flag": "O8:boss_guard",
+            "offset": 53,
+            "size": 7,
+            "value": 23
+        },
+        {
+            "flag": "O8:boss_karate",
+            "offset": 53,
+            "size": 7,
+            "value": 24
+        },
+        {
+            "flag": "O8:boss_baigan",
+            "offset": 53,
+            "size": 7,
+            "value": 25
+        },
+        {
+            "flag": "O8:boss_kainazzo",
+            "offset": 53,
+            "size": 7,
+            "value": 26
+        },
+        {
+            "flag": "O8:boss_darkelf",
+            "offset": 53,
+            "size": 7,
+            "value": 27
+        },
+        {
+            "flag": "O8:boss_magus",
+            "offset": 53,
+            "size": 7,
+            "value": 28
+        },
+        {
+            "flag": "O8:boss_valvalis",
+            "offset": 53,
+            "size": 7,
+            "value": 29
+        },
+        {
+            "flag": "O8:boss_calbrena",
+            "offset": 53,
+            "size": 7,
+            "value": 30
+        },
+        {
+            "flag": "O8:boss_golbez",
+            "offset": 53,
+            "size": 7,
+            "value": 31
+        },
+        {
+            "flag": "O8:boss_lugae",
+            "offset": 53,
+            "size": 7,
+            "value": 32
+        },
+        {
+            "flag": "O8:boss_darkimp",
+            "offset": 53,
+            "size": 7,
+            "value": 33
+        },
+        {
+            "flag": "O8:boss_kingqueen",
+            "offset": 53,
+            "size": 7,
+            "value": 34
+        },
+        {
+            "flag": "O8:boss_rubicant",
+            "offset": 53,
+            "size": 7,
+            "value": 35
+        },
+        {
+            "flag": "O8:boss_evilwall",
+            "offset": 53,
+            "size": 7,
+            "value": 36
+        },
+        {
+            "flag": "O8:boss_asura",
+            "offset": 53,
+            "size": 7,
+            "value": 37
+        },
+        {
+            "flag": "O8:boss_leviatan",
+            "offset": 53,
+            "size": 7,
+            "value": 38
+        },
+        {
+            "flag": "O8:boss_odin",
+            "offset": 53,
+            "size": 7,
+            "value": 39
+        },
+        {
+            "flag": "O8:boss_bahamut",
+            "offset": 53,
+            "size": 7,
+            "value": 40
+        },
+        {
+            "flag": "O8:boss_elements",
+            "offset": 53,
+            "size": 7,
+            "value": 41
+        },
+        {
+            "flag": "O8:boss_cpu",
+            "offset": 53,
+            "size": 7,
+            "value": 42
+        },
+        {
+            "flag": "O8:boss_paledim",
+            "offset": 53,
+            "size": 7,
+            "value": 43
+        },
+        {
+            "flag": "O8:boss_wyvern",
+            "offset": 53,
+            "size": 7,
+            "value": 44
+        },
+        {
+            "flag": "O8:boss_plague",
+            "offset": 53,
+            "size": 7,
+            "value": 45
+        },
+        {
+            "flag": "O8:boss_dlunar",
+            "offset": 53,
+            "size": 7,
+            "value": 46
+        },
+        {
+            "flag": "O8:boss_ogopogo",
+            "offset": 53,
+            "size": 7,
+            "value": 47
+        },
+        {
+            "flag": "O8:quest_mistcave",
+            "offset": 53,
+            "size": 7,
+            "value": 48
+        },
+        {
+            "flag": "O8:quest_waterfall",
+            "offset": 53,
+            "size": 7,
+            "value": 49
+        },
+        {
+            "flag": "O8:quest_antlionnest",
+            "offset": 53,
+            "size": 7,
+            "value": 50
+        },
+        {
+            "flag": "O8:quest_hobs",
+            "offset": 53,
+            "size": 7,
+            "value": 51
+        },
+        {
+            "flag": "O8:quest_fabul",
+            "offset": 53,
+            "size": 7,
+            "value": 52
+        },
+        {
+            "flag": "O8:quest_ordeals",
+            "offset": 53,
+            "size": 7,
+            "value": 53
+        },
+        {
+            "flag": "O8:quest_baroninn",
+            "offset": 53,
+            "size": 7,
+            "value": 54
+        },
+        {
+            "flag": "O8:quest_baroncastle",
+            "offset": 53,
+            "size": 7,
+            "value": 55
+        },
+        {
+            "flag": "O8:quest_magnes",
+            "offset": 53,
+            "size": 7,
+            "value": 56
+        },
+        {
+            "flag": "O8:quest_zot",
+            "offset": 53,
+            "size": 7,
+            "value": 57
+        },
+        {
+            "flag": "O8:quest_dwarfcastle",
+            "offset": 53,
+            "size": 7,
+            "value": 58
+        },
+        {
+            "flag": "O8:quest_lowerbabil",
+            "offset": 53,
+            "size": 7,
+            "value": 59
+        },
+        {
+            "flag": "O8:quest_falcon",
+            "offset": 53,
+            "size": 7,
+            "value": 60
+        },
+        {
+            "flag": "O8:quest_sealedcave",
+            "offset": 53,
+            "size": 7,
+            "value": 61
+        },
+        {
+            "flag": "O8:quest_monsterqueen",
+            "offset": 53,
+            "size": 7,
+            "value": 62
+        },
+        {
+            "flag": "O8:quest_monsterking",
+            "offset": 53,
+            "size": 7,
+            "value": 63
+        },
+        {
+            "flag": "O8:quest_baronbasement",
+            "offset": 53,
+            "size": 7,
+            "value": 64
+        },
+        {
+            "flag": "O8:quest_giant",
+            "offset": 53,
+            "size": 7,
+            "value": 65
+        },
+        {
+            "flag": "O8:quest_cavebahamut",
+            "offset": 53,
+            "size": 7,
+            "value": 66
+        },
+        {
+            "flag": "O8:quest_murasamealtar",
+            "offset": 53,
+            "size": 7,
+            "value": 67
+        },
+        {
+            "flag": "O8:quest_crystalaltar",
+            "offset": 53,
+            "size": 7,
+            "value": 68
+        },
+        {
+            "flag": "O8:quest_whitealtar",
+            "offset": 53,
+            "size": 7,
+            "value": 69
+        },
+        {
+            "flag": "O8:quest_ribbonaltar",
+            "offset": 53,
+            "size": 7,
+            "value": 70
+        },
+        {
+            "flag": "O8:quest_masamunealtar",
+            "offset": 53,
+            "size": 7,
+            "value": 71
+        },
+        {
+            "flag": "O8:quest_burnmist",
+            "offset": 53,
+            "size": 7,
+            "value": 72
+        },
+        {
+            "flag": "O8:quest_curefever",
+            "offset": 53,
+            "size": 7,
+            "value": 73
+        },
+        {
+            "flag": "O8:quest_unlocksewer",
+            "offset": 53,
+            "size": 7,
+            "value": 74
+        },
+        {
+            "flag": "O8:quest_music",
+            "offset": 53,
+            "size": 7,
+            "value": 75
+        },
+        {
+            "flag": "O8:quest_toroiatreasury",
+            "offset": 53,
+            "size": 7,
+            "value": 76
+        },
+        {
+            "flag": "O8:quest_magma",
+            "offset": 53,
+            "size": 7,
+            "value": 77
+        },
+        {
+            "flag": "O8:quest_supercannon",
+            "offset": 53,
+            "size": 7,
+            "value": 78
+        },
+        {
+            "flag": "O8:quest_unlocksealedcave",
+            "offset": 53,
+            "size": 7,
+            "value": 79
+        },
+        {
+            "flag": "O8:quest_bigwhale",
+            "offset": 53,
+            "size": 7,
+            "value": 80
+        },
+        {
+            "flag": "O8:quest_traderat",
+            "offset": 53,
+            "size": 7,
+            "value": 81
+        },
+        {
+            "flag": "O8:quest_forge",
+            "offset": 53,
+            "size": 7,
+            "value": 82
+        },
+        {
+            "flag": "O8:quest_wakeyang",
+            "offset": 53,
+            "size": 7,
+            "value": 83
+        },
+        {
+            "flag": "O8:quest_tradepan",
+            "offset": 53,
+            "size": 7,
+            "value": 84
+        },
+        {
+            "flag": "O8:quest_tradepink",
+            "offset": 53,
+            "size": 7,
+            "value": 85
+        },
+        {
+            "flag": "O8:quest_pass",
+            "offset": 53,
+            "size": 7,
+            "value": 86
+        },
+        {
+            "flag": "Orandom:1",
+            "offset": 60,
+            "size": 4,
+            "value": 1
+        },
+        {
+            "flag": "Orandom:2",
+            "offset": 60,
+            "size": 4,
+            "value": 2
+        },
+        {
+            "flag": "Orandom:3",
+            "offset": 60,
+            "size": 4,
+            "value": 3
+        },
+        {
+            "flag": "Orandom:4",
+            "offset": 60,
+            "size": 4,
+            "value": 4
+        },
+        {
+            "flag": "Orandom:5",
+            "offset": 60,
+            "size": 4,
+            "value": 5
+        },
+        {
+            "flag": "Orandom:6",
+            "offset": 60,
+            "size": 4,
+            "value": 6
+        },
+        {
+            "flag": "Orandom:7",
+            "offset": 60,
+            "size": 4,
+            "value": 7
+        },
+        {
+            "flag": "Orandom:8",
+            "offset": 60,
+            "size": 4,
+            "value": 8
+        },
+        {
+            "flag": "Orandom:quest",
+            "offset": 64,
+            "size": 2,
+            "value": 1
+        },
+        {
+            "flag": "Orandom:tough_quest",
+            "offset": 64,
+            "size": 2,
+            "value": 2
+        },
+        {
+            "flag": "Orandom:boss",
+            "offset": 66,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Orandom:char",
+            "offset": 67,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Oreq:all",
+            "offset": 68,
+            "size": 4,
+            "value": 1
+        },
+        {
+            "flag": "Oreq:1",
+            "offset": 68,
+            "size": 4,
+            "value": 2
+        },
+        {
+            "flag": "Oreq:2",
+            "offset": 68,
+            "size": 4,
+            "value": 3
+        },
+        {
+            "flag": "Oreq:3",
+            "offset": 68,
+            "size": 4,
+            "value": 4
+        },
+        {
+            "flag": "Oreq:4",
+            "offset": 68,
+            "size": 4,
+            "value": 5
+        },
+        {
+            "flag": "Oreq:5",
+            "offset": 68,
+            "size": 4,
+            "value": 6
+        },
+        {
+            "flag": "Oreq:6",
+            "offset": 68,
+            "size": 4,
+            "value": 7
+        },
+        {
+            "flag": "Oreq:7",
+            "offset": 68,
+            "size": 4,
+            "value": 8
+        },
+        {
+            "flag": "Oreq:8",
+            "offset": 68,
+            "size": 4,
+            "value": 9
+        },
+        {
+            "flag": "Oreq:9",
+            "offset": 68,
+            "size": 4,
+            "value": 10
+        },
+        {
+            "flag": "Oreq:10",
+            "offset": 68,
+            "size": 4,
+            "value": 11
+        },
+        {
+            "flag": "Owin:game",
+            "offset": 72,
+            "size": 2,
+            "value": 1
+        },
+        {
+            "flag": "Owin:crystal",
+            "offset": 72,
+            "size": 2,
+            "value": 2
+        },
+        {
+            "flag": "Kmain",
+            "offset": 74,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Ksummon",
+            "offset": 75,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Kmoon",
+            "offset": 76,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Kmiab",
+            "offset": 77,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Knofree",
+            "offset": 78,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Kunsafe",
+            "offset": 79,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Kforce:magma",
+            "offset": 80,
+            "size": 2,
+            "value": 1
+        },
+        {
+            "flag": "Kforce:hook",
+            "offset": 80,
+            "size": 2,
+            "value": 2
+        },
+        {
+            "flag": "Pshop",
+            "offset": 82,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Pkey",
+            "offset": 83,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Pchests",
+            "offset": 84,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstandard",
+            "offset": 85,
+            "size": 2,
+            "value": 1
+        },
+        {
+            "flag": "Crelaxed",
+            "offset": 85,
+            "size": 2,
+            "value": 2
+        },
+        {
+            "flag": "Cnofree",
+            "offset": 87,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cnoearned",
+            "offset": 88,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cmaybe",
+            "offset": 89,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cdistinct:1",
+            "offset": 90,
+            "size": 4,
+            "value": 1
+        },
+        {
+            "flag": "Cdistinct:2",
+            "offset": 90,
+            "size": 4,
+            "value": 2
+        },
+        {
+            "flag": "Cdistinct:3",
+            "offset": 90,
+            "size": 4,
+            "value": 3
+        },
+        {
+            "flag": "Cdistinct:4",
+            "offset": 90,
+            "size": 4,
+            "value": 4
+        },
+        {
+            "flag": "Cdistinct:5",
+            "offset": 90,
+            "size": 4,
+            "value": 5
+        },
+        {
+            "flag": "Cdistinct:6",
+            "offset": 90,
+            "size": 4,
+            "value": 6
+        },
+        {
+            "flag": "Cdistinct:7",
+            "offset": 90,
+            "size": 4,
+            "value": 7
+        },
+        {
+            "flag": "Cdistinct:8",
+            "offset": 90,
+            "size": 4,
+            "value": 8
+        },
+        {
+            "flag": "Cdistinct:9",
+            "offset": 90,
+            "size": 4,
+            "value": 9
+        },
+        {
+            "flag": "Cdistinct:10",
+            "offset": 90,
+            "size": 4,
+            "value": 10
+        },
+        {
+            "flag": "Cdistinct:11",
+            "offset": 90,
+            "size": 4,
+            "value": 11
+        },
+        {
+            "flag": "Cstart:cecil",
+            "offset": 94,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:kain",
+            "offset": 95,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:rydia",
+            "offset": 96,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:tellah",
+            "offset": 97,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:edward",
+            "offset": 98,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:rosa",
+            "offset": 99,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:yang",
+            "offset": 100,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:palom",
+            "offset": 101,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:porom",
+            "offset": 102,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:cid",
+            "offset": 103,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:edge",
+            "offset": 104,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:fusoya",
+            "offset": 105,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:any",
+            "offset": 106,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:not_cecil",
+            "offset": 107,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:not_kain",
+            "offset": 108,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:not_rydia",
+            "offset": 109,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:not_tellah",
+            "offset": 110,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:not_edward",
+            "offset": 111,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:not_rosa",
+            "offset": 112,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:not_yang",
+            "offset": 113,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:not_palom",
+            "offset": 114,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:not_porom",
+            "offset": 115,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:not_cid",
+            "offset": 116,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:not_edge",
+            "offset": 117,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstart:not_fusoya",
+            "offset": 118,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Conly:cecil",
+            "offset": 119,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Conly:kain",
+            "offset": 120,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Conly:rydia",
+            "offset": 121,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Conly:tellah",
+            "offset": 122,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Conly:edward",
+            "offset": 123,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Conly:rosa",
+            "offset": 124,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Conly:yang",
+            "offset": 125,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Conly:palom",
+            "offset": 126,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Conly:porom",
+            "offset": 127,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Conly:cid",
+            "offset": 128,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Conly:edge",
+            "offset": 129,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Conly:fusoya",
+            "offset": 130,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cno:cecil",
+            "offset": 131,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cno:kain",
+            "offset": 132,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cno:rydia",
+            "offset": 133,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cno:tellah",
+            "offset": 134,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cno:edward",
+            "offset": 135,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cno:rosa",
+            "offset": 136,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cno:yang",
+            "offset": 137,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cno:palom",
+            "offset": 138,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cno:porom",
+            "offset": 139,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cno:cid",
+            "offset": 140,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cno:edge",
+            "offset": 141,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cno:fusoya",
+            "offset": 142,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Crestrict:cecil",
+            "offset": 143,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Crestrict:kain",
+            "offset": 144,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Crestrict:rydia",
+            "offset": 145,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Crestrict:tellah",
+            "offset": 146,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Crestrict:edward",
+            "offset": 147,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Crestrict:rosa",
+            "offset": 148,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Crestrict:yang",
+            "offset": 149,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Crestrict:palom",
+            "offset": 150,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Crestrict:porom",
+            "offset": 151,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Crestrict:cid",
+            "offset": 152,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Crestrict:edge",
+            "offset": 153,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Crestrict:fusoya",
+            "offset": 154,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cj:spells",
+            "offset": 155,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cj:abilities",
+            "offset": 156,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cnekkie",
+            "offset": 157,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cnodupes",
+            "offset": 158,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cparty:1",
+            "offset": 159,
+            "size": 3,
+            "value": 1
+        },
+        {
+            "flag": "Cparty:2",
+            "offset": 159,
+            "size": 3,
+            "value": 2
+        },
+        {
+            "flag": "Cparty:3",
+            "offset": 159,
+            "size": 3,
+            "value": 3
+        },
+        {
+            "flag": "Cparty:4",
+            "offset": 159,
+            "size": 3,
+            "value": 4
+        },
+        {
+            "flag": "Cbye",
+            "offset": 162,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cpermajoin",
+            "offset": 163,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cpermadeath",
+            "offset": 164,
+            "size": 2,
+            "value": 1
+        },
+        {
+            "flag": "Cpermadeader",
+            "offset": 164,
+            "size": 2,
+            "value": 2
+        },
+        {
+            "flag": "Chero",
+            "offset": 166,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Tshuffle",
+            "offset": 167,
+            "size": 3,
+            "value": 1
+        },
+        {
+            "flag": "Tstandard",
+            "offset": 167,
+            "size": 3,
+            "value": 2
+        },
+        {
+            "flag": "Tpro",
+            "offset": 167,
+            "size": 3,
+            "value": 3
+        },
+        {
+            "flag": "Twild",
+            "offset": 167,
+            "size": 3,
+            "value": 4
+        },
+        {
+            "flag": "Twildish",
+            "offset": 167,
+            "size": 3,
+            "value": 5
+        },
+        {
+            "flag": "Tempty",
+            "offset": 167,
+            "size": 3,
+            "value": 6
+        },
+        {
+            "flag": "Tsparse:10",
+            "offset": 170,
+            "size": 4,
+            "value": 1
+        },
+        {
+            "flag": "Tsparse:20",
+            "offset": 170,
+            "size": 4,
+            "value": 2
+        },
+        {
+            "flag": "Tsparse:30",
+            "offset": 170,
+            "size": 4,
+            "value": 3
+        },
+        {
+            "flag": "Tsparse:40",
+            "offset": 170,
+            "size": 4,
+            "value": 4
+        },
+        {
+            "flag": "Tsparse:50",
+            "offset": 170,
+            "size": 4,
+            "value": 5
+        },
+        {
+            "flag": "Tsparse:60",
+            "offset": 170,
+            "size": 4,
+            "value": 6
+        },
+        {
+            "flag": "Tsparse:70",
+            "offset": 170,
+            "size": 4,
+            "value": 7
+        },
+        {
+            "flag": "Tsparse:80",
+            "offset": 170,
+            "size": 4,
+            "value": 8
+        },
+        {
+            "flag": "Tsparse:90",
+            "offset": 170,
+            "size": 4,
+            "value": 9
+        },
+        {
+            "flag": "Tno:j",
+            "offset": 174,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Tmaxtier:3",
+            "offset": 175,
+            "size": 3,
+            "value": 1
+        },
+        {
+            "flag": "Tmaxtier:4",
+            "offset": 175,
+            "size": 3,
+            "value": 2
+        },
+        {
+            "flag": "Tmaxtier:5",
+            "offset": 175,
+            "size": 3,
+            "value": 3
+        },
+        {
+            "flag": "Tmaxtier:6",
+            "offset": 175,
+            "size": 3,
+            "value": 4
+        },
+        {
+            "flag": "Tmaxtier:7",
+            "offset": 175,
+            "size": 3,
+            "value": 5
+        },
+        {
+            "flag": "Tmoney",
+            "offset": 178,
+            "size": 2,
+            "value": 1
+        },
+        {
+            "flag": "Tjunk",
+            "offset": 178,
+            "size": 2,
+            "value": 2
+        },
+        {
+            "flag": "Sshuffle",
+            "offset": 180,
+            "size": 3,
+            "value": 1
+        },
+        {
+            "flag": "Sstandard",
+            "offset": 180,
+            "size": 3,
+            "value": 2
+        },
+        {
+            "flag": "Spro",
+            "offset": 180,
+            "size": 3,
+            "value": 3
+        },
+        {
+            "flag": "Swild",
+            "offset": 180,
+            "size": 3,
+            "value": 4
+        },
+        {
+            "flag": "Scabins",
+            "offset": 180,
+            "size": 3,
+            "value": 5
+        },
+        {
+            "flag": "Sempty",
+            "offset": 180,
+            "size": 3,
+            "value": 6
+        },
+        {
+            "flag": "Sfree",
+            "offset": 183,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Ssell:quarter",
+            "offset": 184,
+            "size": 2,
+            "value": 1
+        },
+        {
+            "flag": "Ssell:0",
+            "offset": 184,
+            "size": 2,
+            "value": 2
+        },
+        {
+            "flag": "Sno:j",
+            "offset": 186,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Sno:apples",
+            "offset": 187,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Sno:sirens",
+            "offset": 188,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Sno:life",
+            "offset": 189,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Sunsafe",
+            "offset": 190,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Bstandard",
+            "offset": 191,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Bnofree",
+            "offset": 192,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Bunsafe",
+            "offset": 193,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Balt:gauntlet",
+            "offset": 194,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Bwhyburn",
+            "offset": 195,
+            "size": 2,
+            "value": 1
+        },
+        {
+            "flag": "Bwhichburn",
+            "offset": 195,
+            "size": 2,
+            "value": 2
+        },
+        {
+            "flag": "Etoggle",
+            "offset": 197,
+            "size": 2,
+            "value": 1
+        },
+        {
+            "flag": "Ereduce",
+            "offset": 197,
+            "size": 2,
+            "value": 2
+        },
+        {
+            "flag": "Enoencounters",
+            "offset": 197,
+            "size": 2,
+            "value": 3
+        },
+        {
+            "flag": "Ekeep:doors",
+            "offset": 199,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Ekeep:behemoths",
+            "offset": 200,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Edanger",
+            "offset": 201,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Ecantrun",
+            "offset": 202,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Enoexp",
+            "offset": 203,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Eno:jdrops",
+            "offset": 204,
+            "size": 2,
+            "value": 1
+        },
+        {
+            "flag": "Eno:sirens",
+            "offset": 204,
+            "size": 2,
+            "value": 2
+        },
+        {
+            "flag": "Gdupe",
+            "offset": 206,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Gmp",
+            "offset": 207,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Gwarp",
+            "offset": 208,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Glife",
+            "offset": 209,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Gsylph",
+            "offset": 210,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Gbackrow",
+            "offset": 211,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "G64",
+            "offset": 212,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-kit:basic",
+            "offset": 213,
+            "size": 5,
+            "value": 1
+        },
+        {
+            "flag": "-kit:better",
+            "offset": 213,
+            "size": 5,
+            "value": 2
+        },
+        {
+            "flag": "-kit:loaded",
+            "offset": 213,
+            "size": 5,
+            "value": 3
+        },
+        {
+            "flag": "-kit:cata",
+            "offset": 213,
+            "size": 5,
+            "value": 4
+        },
+        {
+            "flag": "-kit:freedom",
+            "offset": 213,
+            "size": 5,
+            "value": 5
+        },
+        {
+            "flag": "-kit:cid",
+            "offset": 213,
+            "size": 5,
+            "value": 6
+        },
+        {
+            "flag": "-kit:yang",
+            "offset": 213,
+            "size": 5,
+            "value": 7
+        },
+        {
+            "flag": "-kit:money",
+            "offset": 213,
+            "size": 5,
+            "value": 8
+        },
+        {
+            "flag": "-kit:grabbag",
+            "offset": 213,
+            "size": 5,
+            "value": 9
+        },
+        {
+            "flag": "-kit:miab",
+            "offset": 213,
+            "size": 5,
+            "value": 10
+        },
+        {
+            "flag": "-kit:archer",
+            "offset": 213,
+            "size": 5,
+            "value": 11
+        },
+        {
+            "flag": "-kit:fabul",
+            "offset": 213,
+            "size": 5,
+            "value": 12
+        },
+        {
+            "flag": "-kit:castlevania",
+            "offset": 213,
+            "size": 5,
+            "value": 13
+        },
+        {
+            "flag": "-kit:summon",
+            "offset": 213,
+            "size": 5,
+            "value": 14
+        },
+        {
+            "flag": "-kit:notdeme",
+            "offset": 213,
+            "size": 5,
+            "value": 15
+        },
+        {
+            "flag": "-kit:meme",
+            "offset": 213,
+            "size": 5,
+            "value": 16
+        },
+        {
+            "flag": "-kit:defense",
+            "offset": 213,
+            "size": 5,
+            "value": 17
+        },
+        {
+            "flag": "-kit:mist",
+            "offset": 213,
+            "size": 5,
+            "value": 18
+        },
+        {
+            "flag": "-kit:mysidia",
+            "offset": 213,
+            "size": 5,
+            "value": 19
+        },
+        {
+            "flag": "-kit:baron",
+            "offset": 213,
+            "size": 5,
+            "value": 20
+        },
+        {
+            "flag": "-kit:dwarf",
+            "offset": 213,
+            "size": 5,
+            "value": 21
+        },
+        {
+            "flag": "-kit:eblan",
+            "offset": 213,
+            "size": 5,
+            "value": 22
+        },
+        {
+            "flag": "-kit:libra",
+            "offset": 213,
+            "size": 5,
+            "value": 23
+        },
+        {
+            "flag": "-kit:99",
+            "offset": 213,
+            "size": 5,
+            "value": 24
+        },
+        {
+            "flag": "-kit:green",
+            "offset": 213,
+            "size": 5,
+            "value": 25
+        },
+        {
+            "flag": "-kit:random",
+            "offset": 213,
+            "size": 5,
+            "value": 26
+        },
+        {
+            "flag": "-kit2:basic",
+            "offset": 218,
+            "size": 5,
+            "value": 1
+        },
+        {
+            "flag": "-kit2:better",
+            "offset": 218,
+            "size": 5,
+            "value": 2
+        },
+        {
+            "flag": "-kit2:loaded",
+            "offset": 218,
+            "size": 5,
+            "value": 3
+        },
+        {
+            "flag": "-kit2:cata",
+            "offset": 218,
+            "size": 5,
+            "value": 4
+        },
+        {
+            "flag": "-kit2:freedom",
+            "offset": 218,
+            "size": 5,
+            "value": 5
+        },
+        {
+            "flag": "-kit2:cid",
+            "offset": 218,
+            "size": 5,
+            "value": 6
+        },
+        {
+            "flag": "-kit2:yang",
+            "offset": 218,
+            "size": 5,
+            "value": 7
+        },
+        {
+            "flag": "-kit2:money",
+            "offset": 218,
+            "size": 5,
+            "value": 8
+        },
+        {
+            "flag": "-kit2:grabbag",
+            "offset": 218,
+            "size": 5,
+            "value": 9
+        },
+        {
+            "flag": "-kit2:miab",
+            "offset": 218,
+            "size": 5,
+            "value": 10
+        },
+        {
+            "flag": "-kit2:archer",
+            "offset": 218,
+            "size": 5,
+            "value": 11
+        },
+        {
+            "flag": "-kit2:fabul",
+            "offset": 218,
+            "size": 5,
+            "value": 12
+        },
+        {
+            "flag": "-kit2:castlevania",
+            "offset": 218,
+            "size": 5,
+            "value": 13
+        },
+        {
+            "flag": "-kit2:summon",
+            "offset": 218,
+            "size": 5,
+            "value": 14
+        },
+        {
+            "flag": "-kit2:notdeme",
+            "offset": 218,
+            "size": 5,
+            "value": 15
+        },
+        {
+            "flag": "-kit2:meme",
+            "offset": 218,
+            "size": 5,
+            "value": 16
+        },
+        {
+            "flag": "-kit2:defense",
+            "offset": 218,
+            "size": 5,
+            "value": 17
+        },
+        {
+            "flag": "-kit2:mist",
+            "offset": 218,
+            "size": 5,
+            "value": 18
+        },
+        {
+            "flag": "-kit2:mysidia",
+            "offset": 218,
+            "size": 5,
+            "value": 19
+        },
+        {
+            "flag": "-kit2:baron",
+            "offset": 218,
+            "size": 5,
+            "value": 20
+        },
+        {
+            "flag": "-kit2:dwarf",
+            "offset": 218,
+            "size": 5,
+            "value": 21
+        },
+        {
+            "flag": "-kit2:eblan",
+            "offset": 218,
+            "size": 5,
+            "value": 22
+        },
+        {
+            "flag": "-kit2:libra",
+            "offset": 218,
+            "size": 5,
+            "value": 23
+        },
+        {
+            "flag": "-kit2:99",
+            "offset": 218,
+            "size": 5,
+            "value": 24
+        },
+        {
+            "flag": "-kit2:green",
+            "offset": 218,
+            "size": 5,
+            "value": 25
+        },
+        {
+            "flag": "-kit2:random",
+            "offset": 218,
+            "size": 5,
+            "value": 26
+        },
+        {
+            "flag": "-kit3:basic",
+            "offset": 223,
+            "size": 5,
+            "value": 1
+        },
+        {
+            "flag": "-kit3:better",
+            "offset": 223,
+            "size": 5,
+            "value": 2
+        },
+        {
+            "flag": "-kit3:loaded",
+            "offset": 223,
+            "size": 5,
+            "value": 3
+        },
+        {
+            "flag": "-kit3:cata",
+            "offset": 223,
+            "size": 5,
+            "value": 4
+        },
+        {
+            "flag": "-kit3:freedom",
+            "offset": 223,
+            "size": 5,
+            "value": 5
+        },
+        {
+            "flag": "-kit3:cid",
+            "offset": 223,
+            "size": 5,
+            "value": 6
+        },
+        {
+            "flag": "-kit3:yang",
+            "offset": 223,
+            "size": 5,
+            "value": 7
+        },
+        {
+            "flag": "-kit3:money",
+            "offset": 223,
+            "size": 5,
+            "value": 8
+        },
+        {
+            "flag": "-kit3:grabbag",
+            "offset": 223,
+            "size": 5,
+            "value": 9
+        },
+        {
+            "flag": "-kit3:miab",
+            "offset": 223,
+            "size": 5,
+            "value": 10
+        },
+        {
+            "flag": "-kit3:archer",
+            "offset": 223,
+            "size": 5,
+            "value": 11
+        },
+        {
+            "flag": "-kit3:fabul",
+            "offset": 223,
+            "size": 5,
+            "value": 12
+        },
+        {
+            "flag": "-kit3:castlevania",
+            "offset": 223,
+            "size": 5,
+            "value": 13
+        },
+        {
+            "flag": "-kit3:summon",
+            "offset": 223,
+            "size": 5,
+            "value": 14
+        },
+        {
+            "flag": "-kit3:notdeme",
+            "offset": 223,
+            "size": 5,
+            "value": 15
+        },
+        {
+            "flag": "-kit3:meme",
+            "offset": 223,
+            "size": 5,
+            "value": 16
+        },
+        {
+            "flag": "-kit3:defense",
+            "offset": 223,
+            "size": 5,
+            "value": 17
+        },
+        {
+            "flag": "-kit3:mist",
+            "offset": 223,
+            "size": 5,
+            "value": 18
+        },
+        {
+            "flag": "-kit3:mysidia",
+            "offset": 223,
+            "size": 5,
+            "value": 19
+        },
+        {
+            "flag": "-kit3:baron",
+            "offset": 223,
+            "size": 5,
+            "value": 20
+        },
+        {
+            "flag": "-kit3:dwarf",
+            "offset": 223,
+            "size": 5,
+            "value": 21
+        },
+        {
+            "flag": "-kit3:eblan",
+            "offset": 223,
+            "size": 5,
+            "value": 22
+        },
+        {
+            "flag": "-kit3:libra",
+            "offset": 223,
+            "size": 5,
+            "value": 23
+        },
+        {
+            "flag": "-kit3:99",
+            "offset": 223,
+            "size": 5,
+            "value": 24
+        },
+        {
+            "flag": "-kit3:green",
+            "offset": 223,
+            "size": 5,
+            "value": 25
+        },
+        {
+            "flag": "-kit3:random",
+            "offset": 223,
+            "size": 5,
+            "value": 26
+        },
+        {
+            "flag": "-noadamants",
+            "offset": 228,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-nocursed",
+            "offset": 229,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-spoon",
+            "offset": 230,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-smith:super",
+            "offset": 231,
+            "size": 2,
+            "value": 1
+        },
+        {
+            "flag": "-smith:alt",
+            "offset": 231,
+            "size": 2,
+            "value": 2
+        },
+        {
+            "flag": "-exp:split",
+            "offset": 233,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-exp:noboost",
+            "offset": 234,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-exp:nokeybonus",
+            "offset": 235,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:fusoya",
+            "offset": 236,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:agility",
+            "offset": 237,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:hobs",
+            "offset": 238,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:growup",
+            "offset": 239,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:fashion",
+            "offset": 240,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:miabs",
+            "offset": 241,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:giant",
+            "offset": 242,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:z",
+            "offset": 243,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vintage",
+            "offset": 244,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-pushbtojump",
+            "offset": 245,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-wacky:random",
+            "offset": 246,
+            "size": 6,
+            "value": 1
+        },
+        {
+            "flag": "-wacky:musical",
+            "offset": 246,
+            "size": 6,
+            "value": 2
+        },
+        {
+            "flag": "-wacky:bodyguard",
+            "offset": 246,
+            "size": 6,
+            "value": 3
+        },
+        {
+            "flag": "-wacky:fistfight",
+            "offset": 246,
+            "size": 6,
+            "value": 4
+        },
+        {
+            "flag": "-wacky:omnidextrous",
+            "offset": 246,
+            "size": 6,
+            "value": 5
+        },
+        {
+            "flag": "-wacky:biggermagnet",
+            "offset": 246,
+            "size": 6,
+            "value": 6
+        },
+        {
+            "flag": "-wacky:sixleggedrace",
+            "offset": 246,
+            "size": 6,
+            "value": 7
+        },
+        {
+            "flag": "-wacky:floorislava",
+            "offset": 246,
+            "size": 6,
+            "value": 8
+        },
+        {
+            "flag": "-wacky:neatfreak",
+            "offset": 246,
+            "size": 6,
+            "value": 9
+        },
+        {
+            "flag": "-wacky:timeismoney",
+            "offset": 246,
+            "size": 6,
+            "value": 10
+        },
+        {
+            "flag": "-wacky:nightmode",
+            "offset": 246,
+            "size": 6,
+            "value": 11
+        },
+        {
+            "flag": "-wacky:mysteryjuice",
+            "offset": 246,
+            "size": 6,
+            "value": 12
+        },
+        {
+            "flag": "-wacky:misspelled",
+            "offset": 246,
+            "size": 6,
+            "value": 13
+        },
+        {
+            "flag": "-wacky:enemyunknown",
+            "offset": 246,
+            "size": 6,
+            "value": 14
+        },
+        {
+            "flag": "-wacky:kleptomania",
+            "offset": 246,
+            "size": 6,
+            "value": 15
+        },
+        {
+            "flag": "-wacky:darts",
+            "offset": 246,
+            "size": 6,
+            "value": 16
+        },
+        {
+            "flag": "-wacky:unstackable",
+            "offset": 246,
+            "size": 6,
+            "value": 17
+        },
+        {
+            "flag": "-wacky:menarepigs",
+            "offset": 246,
+            "size": 6,
+            "value": 18
+        },
+        {
+            "flag": "-wacky:skywarriors",
+            "offset": 246,
+            "size": 6,
+            "value": 19
+        },
+        {
+            "flag": "-wacky:zombies",
+            "offset": 246,
+            "size": 6,
+            "value": 20
+        },
+        {
+            "flag": "-wacky:afflicted",
+            "offset": 246,
+            "size": 6,
+            "value": 21
+        },
+        {
+            "flag": "-wacky:batman",
+            "offset": 246,
+            "size": 6,
+            "value": 22
+        },
+        {
+            "flag": "-wacky:battlescars",
+            "offset": 246,
+            "size": 6,
+            "value": 23
+        },
+        {
+            "flag": "-wacky:imaginarynumbers",
+            "offset": 246,
+            "size": 6,
+            "value": 24
+        },
+        {
+            "flag": "-wacky:tellahmaneuver",
+            "offset": 246,
+            "size": 6,
+            "value": 25
+        },
+        {
+            "flag": "-wacky:3point",
+            "offset": 246,
+            "size": 6,
+            "value": 26
+        },
+        {
+            "flag": "-wacky:friendlyfire",
+            "offset": 246,
+            "size": 6,
+            "value": 27
+        },
+        {
+            "flag": "-wacky:payablegolbez",
+            "offset": 246,
+            "size": 6,
+            "value": 28
+        },
+        {
+            "flag": "-wacky:gottagofast",
+            "offset": 246,
+            "size": 6,
+            "value": 29
+        },
+        {
+            "flag": "-wacky:worthfighting",
+            "offset": 246,
+            "size": 6,
+            "value": 30
+        },
+        {
+            "flag": "-wacky:saveusbigchocobo",
+            "offset": 246,
+            "size": 6,
+            "value": 31
+        },
+        {
+            "flag": "-wacky:isthisrandomized",
+            "offset": 246,
+            "size": 6,
+            "value": 32
+        },
+        {
+            "flag": "-wacky:forwardisback",
+            "offset": 246,
+            "size": 6,
+            "value": 33
+        },
+        {
+            "flag": "-spoil:all",
+            "offset": 252,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-spoil:keyitems",
+            "offset": 253,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-spoil:rewards",
+            "offset": 254,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-spoil:chars",
+            "offset": 255,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-spoil:treasure",
+            "offset": 256,
+            "size": 2,
+            "value": 1
+        },
+        {
+            "flag": "-spoil:miabs",
+            "offset": 256,
+            "size": 2,
+            "value": 2
+        },
+        {
+            "flag": "-spoil:shops",
+            "offset": 258,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-spoil:bosses",
+            "offset": 259,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-spoil:misc",
+            "offset": 260,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-spoil:sparse10",
+            "offset": 261,
+            "size": 4,
+            "value": 1
+        },
+        {
+            "flag": "-spoil:sparse20",
+            "offset": 261,
+            "size": 4,
+            "value": 2
+        },
+        {
+            "flag": "-spoil:sparse30",
+            "offset": 261,
+            "size": 4,
+            "value": 3
+        },
+        {
+            "flag": "-spoil:sparse40",
+            "offset": 261,
+            "size": 4,
+            "value": 4
+        },
+        {
+            "flag": "-spoil:sparse50",
+            "offset": 261,
+            "size": 4,
+            "value": 5
+        },
+        {
+            "flag": "-spoil:sparse60",
+            "offset": 261,
+            "size": 4,
+            "value": 6
+        },
+        {
+            "flag": "-spoil:sparse70",
+            "offset": 261,
+            "size": 4,
+            "value": 7
+        },
+        {
+            "flag": "-spoil:sparse80",
+            "offset": 261,
+            "size": 4,
+            "value": 8
+        },
+        {
+            "flag": "-spoil:sparse90",
+            "offset": 261,
+            "size": 4,
+            "value": 9
+        }
+    ],
+    "rules": {},
+    "rule_references": {}
+}

--- a/src/test/java/sg4e/ff4stats/fe/FlagSetCompatibilityTest.java
+++ b/src/test/java/sg4e/ff4stats/fe/FlagSetCompatibilityTest.java
@@ -10,6 +10,8 @@ public class FlagSetCompatibilityTest {
 
     private static final String MODERN_COMPAT_STRING =
             "Kmain/summon/moon/nofree Pkey Cstandard/nofree/j:spells,abilities Twild Sstandard/no:apples Bstandard Etoggle Glife/sylph/backrow/mp -spoon -vanilla:fusoya";
+    private static final String MODERN_COMPAT_STRING_WITH_ONONE =
+            "Onone " + MODERN_COMPAT_STRING;
     private static final String MODERN_COMPAT_BINARY =
             "bBAUAAAAAAAAAAAAAXKgAAAAAAAAAABgAAiCIIIAOAEAQ";
 
@@ -42,6 +44,14 @@ public class FlagSetCompatibilityTest {
         assertEquals(fromString.getFlags(), fromBinary.getFlags());
         assertEquals(fromString.toString(), fromStringBinary.toString());
         assertEquals(fromString.getFlags(), fromStringBinary.getFlags());
+    }
+
+    @Test
+    public void ononePrefixDoesNotCorruptModernParsing() {
+        FlagSet withOnone = FlagSet.fromString(MODERN_COMPAT_STRING_WITH_ONONE);
+        FlagSet withoutOnone = FlagSet.fromString(MODERN_COMPAT_STRING);
+        assertEquals(withoutOnone.getBinary(), withOnone.getBinary());
+        assertEquals(withoutOnone.toString(), withOnone.toString());
     }
 
     @Test

--- a/src/test/java/sg4e/ff4stats/fe/FlagSetCompatibilityTest.java
+++ b/src/test/java/sg4e/ff4stats/fe/FlagSetCompatibilityTest.java
@@ -1,0 +1,57 @@
+package sg4e.ff4stats.fe;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class FlagSetCompatibilityTest {
+
+    private static final String MODERN_COMPAT_STRING =
+            "Kmain/summon/moon/nofree Pkey Cstandard/nofree/j:spells,abilities Twild Sstandard/no:apples Bstandard Etoggle Glife/sylph/backrow/mp -spoon -vanilla:fusoya";
+    private static final String MODERN_COMPAT_BINARY =
+            "bBAUAAAAAAAAAAAAAXKgAAAAAAAAAABgAAiCIIIAOAEAQ";
+
+    @Test
+    public void modernStringParsesAndEncodesToExpectedBinary() {
+        FlagSet fromString = FlagSet.fromString(MODERN_COMPAT_STRING);
+        assertEquals(MODERN_COMPAT_BINARY, fromString.getBinary());
+        assertTrue(fromString.contains("Kmain"));
+        assertTrue(fromString.contains("Knofree"));
+        assertTrue(fromString.contains("Cnofree"));
+        assertTrue(fromString.contains("Cj:spells"));
+        assertTrue(fromString.contains("Cj:abilities"));
+        assertTrue(fromString.contains("Gsylph"));
+        assertTrue(fromString.contains("Gbackrow"));
+        assertTrue(fromString.contains("Gmp"));
+        assertTrue(fromString.contains("-spoon"));
+        assertTrue(fromString.contains("-vanilla:fusoya"));
+        assertFalse(fromString.hasSeed());
+    }
+
+    @Test
+    public void modernBinaryParsesAndRoundtripsToCanonicalString() {
+        FlagSet fromString = FlagSet.fromString(MODERN_COMPAT_STRING);
+        FlagSet fromBinary = FlagSet.fromBinary(MODERN_COMPAT_BINARY);
+        assertEquals(MODERN_COMPAT_BINARY, fromBinary.getBinary());
+        assertFalse(fromBinary.hasSeed());
+        FlagSet fromStringBinary = FlagSet.fromBinary(fromString.getBinary());
+
+        assertEquals(fromString.toString(), fromBinary.toString());
+        assertEquals(fromString.getFlags(), fromBinary.getFlags());
+        assertEquals(fromString.toString(), fromStringBinary.toString());
+        assertEquals(fromString.getFlags(), fromStringBinary.getFlags());
+    }
+
+    @Test
+    public void legacyFormattingIsPreservedForLegacyVersions() {
+        FlagSet legacy = FlagSet.fromBinary("bAAMCJCQEAMAJBa8O");
+        assertEquals(legacy.toStringLegacyStyle(), legacy.toString());
+    }
+
+    @Test
+    public void canonicalFormattingPathIsEnabledForModernVersion() {
+        FlagSet modern = FlagSet.fromString("Kmain");
+        assertEquals(modern.toStringCanonical(), modern.toString());
+    }
+}

--- a/src/test/java/sg4e/ff4stats/fe/FlagSetCompatibilityTest.java
+++ b/src/test/java/sg4e/ff4stats/fe/FlagSetCompatibilityTest.java
@@ -3,6 +3,7 @@ package sg4e.ff4stats.fe;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 import org.junit.Test;
 
 public class FlagSetCompatibilityTest {
@@ -53,5 +54,10 @@ public class FlagSetCompatibilityTest {
     public void canonicalFormattingPathIsEnabledForModernVersion() {
         FlagSet modern = FlagSet.fromString("Kmain");
         assertEquals(modern.toStringCanonical(), modern.toString());
+    }
+
+    @Test
+    public void incompatibleFlagsFailWithIllegalArgumentExceptionNotNullPointer() {
+        assertThrows(IllegalArgumentException.class, () -> FlagSet.fromString("Qnotaflag"));
     }
 }


### PR DESCRIPTION
### Motivation

- Add support for the new flag specification version `4.5.0` and ensure canonical string formatting is used for modern versions while preserving legacy formatting for older versions.
- Improve parsing robustness when switching FlagVersion mid-parse and ensure human-readable ↔ binary roundtrip compatibility.

### Description

- Introduce `VERSION_4_5_0` in `FlagVersion`, add the `4-5-0.json` flag spec resource, and change `latest` to `4.5.0` so new specs are recognized and loaded.
- Update version-detection ordering in `FlagVersion.getVersionFromFlagString` and `getFromVersionString` so `4.5.0` is considered before older versions.
- Add a `canonicalFormatting` mode to `FlagSet` with `toString()` delegating to either `toStringCanonical()` or legacy `toStringLegacyStyle()`, and call `configureFormattingMode()` when building `FlagSet` instances from strings or binaries.
- Harden parsing in `FlagSet.from(...)` by extracting token handling (`flagToken`) and checking for unrecognized flags after version changes to avoid null dereferences.
- Add `FlagSetCompatibilityTest` covering parsing/encoding for modern strings and binaries, roundtrip comparisons, and ensuring legacy formatting is preserved for older versions.

### Testing

- Added unit tests in `FlagSetCompatibilityTest` exercising modern string→binary encoding, binary→string roundtrip, legacy formatting preservation, and canonical formatting activation; all tests in that class passed.
- Ran the automated test suite (`mvn test`), and the modified tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17a80a2d84832da8f9a55b23b6bf48)