### PR TITLE
Add comprehensive project and API documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,75 @@
+# FF4StatsLib documentation
+
+FF4StatsLib is a Java 8 library for programs that analyze Final Fantasy IV data and Final Fantasy IV: Free Enterprise (FF4FE) seeds. It bundles game data as classpath resources and exposes object models for:
+
+- boss substitutions, formations, and enemy statistics;
+- character levels, experience thresholds, deterministic and possible stat growth, HP, and MP;
+- weapons, armor, and their stat modifiers;
+- FF4FE human-readable flags, binary flags, version-specific flag specifications, and seed URLs; and
+- key items and the locations accessible with a given inventory.
+
+The library has no executable entry point, command-line interface, server, or persistence layer. Consumers call its Java API; most reference data is loaded lazily when the corresponding class or enum is initialized.
+
+## Documentation map
+
+- [Getting started and common recipes](getting-started.md) — build the project, put it on a classpath, and perform common tasks.
+- [Architecture and data flow](architecture.md) — understand packages, resource loading, initialization, algorithms, and extension points.
+- [API reference](api-reference.md) — detailed behavior of every public type and method.
+- [Data files and maintenance](data-files.md) — resource formats, dependencies, test strategy, and guidance for changing the library.
+- [Behavioral caveats](#behavioral-caveats) — important mutability, failure, and compatibility details.
+
+## Project at a glance
+
+| Area | Main entry points | Backing resources |
+| --- | --- | --- |
+| Boss data | `Battle.getAllBosses()`, `Formation.getFor(...)` | `bosses.csv` |
+| Character progression | `LevelData`, `PartyMember` | `party/*.csv` plus in-code post-level-70 growth tables |
+| Equipment | `Weapon.getWeapon(...)`, `Armor.getArmor(...)` | `equipment/weapons.csv`, `equipment/armor.csv` |
+| FF4FE flags | `FlagSet.from(...)`, `FlagVersion` | `fe/flagVersions/*.csv` and `*.json` |
+| Key-item routing | `KeyItem`, `KeyItemLocation.getAccessibleLocations(...)` | enum declarations in Java source |
+| Generic resource CSV access | `CSVParser`, `RecordParser` | any RFC 4180 CSV visible to the system class loader |
+
+## Supported runtime and build
+
+- The Gradle `java-library` plugin builds the project.
+- Source and target compatibility are Java 8.
+- `./gradlew test` runs the JUnit 4 test suite.
+- `./gradlew build` creates the library JAR under `build/libs/`.
+- The build does not configure a Maven group, artifact version, publishing repository, or application entry point. To consume a local build, add the generated JAR and its runtime dependencies to your application, or include this project as a Gradle project dependency.
+
+The implementation depends on Apache Commons CSV, Apache Commons Text, Guava, Jackson Databind, and SLF4J API. See [Data files and maintenance](data-files.md#dependencies) for why each is used.
+
+## Design principles
+
+### Data is shipped with the library
+
+Most lookups do not reach the network or a database. CSV and JSON resources in `src/main/resources` are packaged into the JAR and read through a class loader. This makes queries fast and reproducible, but changing reference data requires rebuilding the library.
+
+### Domain objects and lookup catalogs are separate
+
+Classes such as `Enemy`, `Battle`, `Stats`, `Weapon`, and `Armor` are value-like data holders. Static catalogs such as `Battle.getAllBosses()`, `Weapon.getWeapon(...)`, and enum constants in `LevelData` provide the bundled canonical data.
+
+### FF4FE flags are versioned bit fields
+
+A `FlagVersion` loads a flag specification describing each flag's name, bit offset, bit width, and encoded value. `FlagSet` converts between human-readable flags, URL-safe Base64 binary flags, and FF4FE URLs. Modern JSON specifications can also define rules that automatically enable or disable related flags.
+
+### Character statistics distinguish guaranteed and possible growth
+
+Levels through 70 use the bundled per-character CSV tables. Levels above 70 use one of eight growth-table rows. `getStatsForLevel(...)` follows a deterministic row choice, while minimum/maximum methods calculate the possible bounds across all growth rows.
+
+## Behavioral caveats
+
+These details are significant when integrating the API:
+
+1. **Some returned collections are mutable live collections.** `Formation.getAllEnemies()`, `Enemy.getScriptValues()`, and `FlagVersion.getAllFlags()` expose their underlying lists. Mutating them changes the object/catalog visible to later callers. Treat them as read-only. In contrast, `Battle.getAllBosses()` and `CSVParser.Records` are unmodifiable wrappers, `FlagSet.getFlags()` returns a copy, and `KeyItemLocation.getRequiredItemsForAccess()` returns a copy.
+2. **Lookup keys are case-sensitive unless documented otherwise.** Equipment lookups lowercase both name and type internally. `Formation.getFor(...)` and `Battle` equality use exact strings, so callers should use the title-cased boss and position names found in the bundled catalog.
+3. **Resource-load failures are often logged rather than thrown.** Static boss/equipment/level/flag loaders catch broad exceptions and log through SLF4J. A missing or malformed resource can therefore result in empty catalogs, `null` values, or later failures. Provide an SLF4J binding in applications where diagnostics matter.
+4. **Method names preserve historical misspellings.** The public enemy methods are `getAttackMultipler()` and `getDefenseMultipler()`, and the flag-version method is `getSeperator()`. Consumers must use these exact spellings.
+5. **`PartyMember.gainXp(...)` does not validate the delta.** Negative XP and XP beyond expected bounds are not explicitly rejected. Use sensible non-negative inputs within the game's supported range.
+6. **The library is not uniformly immutable or thread-safe.** Static catalogs initialize safely through JVM class initialization, but mutable returned lists and mutable `PartyMember`, `Formation`, and `FlagSet` internals should not be shared across threads without external coordination.
+7. **`Stats` has equality but no custom `toString()`.** Log or display individual getters if human-readable output is required.
+8. **This documentation describes the implementation, not every FF4/FF4FE game rule.** In particular, key-item accessibility models only the gates encoded by `KeyItemLocation`.
+
+## License
+
+The project is distributed under the GNU General Public License version 3 or later. See `LICENSE.txt` at the repository root.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,201 @@
+# API reference
+
+This reference covers every public top-level type. Signatures that expose Guava, Commons CSV, Jackson, or JavaBeans types require those dependencies on the consumer's compile/runtime classpath as appropriate.
+
+## Bosses and enemies — `sg4e.ff4stats`
+
+### `Battle`
+
+A `(boss, position)` lookup key. Both fields are required by convention but the constructor does not validate `null`.
+
+- `Battle(String boss, String position)` — creates a key using exact strings.
+- `static Map<Battle, Formation> getAllBosses()` — returns the unmodifiable, classpath-loaded boss map.
+- `String getBoss()` / `String getPosition()` — return key components.
+- `equals(Object)` / `hashCode()` — compare both components and make `Battle` suitable as a map key.
+- `toString()` — returns `<boss> @ <position>`.
+
+### `Formation`
+
+An ordered list of enemies belonging to one boss/position pairing.
+
+- `Formation()` — starts empty.
+- `void addEnemy(Enemy enemy)` — appends an enemy; accepts `null` because no validation is performed.
+- `List<Enemy> getAllEnemies()` — returns the live mutable list.
+- `static Formation getFor(String boss, String position)` — exact lookup using a temporary `Battle`; returns `null` when absent.
+- `toString()` — joins enemy `toString()` values in `Formation{...}`.
+
+### `Enemy`
+
+A complete enemy-stat row. The long public constructor accepts, in order: name; level; HP; EXP; GP; attack multiplier; hit percent; attack; defense multiplier; evasion percent; defense; magic-defense multiplier; magic-evasion percentage; magic defense; min speed; max speed; spell power; script values.
+
+- `static Enemy fromRecord(RecordParser record)` — maps columns 2–18 to the fixed fields and columns 19 onward to script values. It assumes the `bosses.csv` column order.
+- Getters expose every constructor field. Historical method spellings `getAttackMultipler()` and `getDefenseMultipler()` must be used exactly.
+- `List<String> getScriptValues()` returns the live supplied list; neither the constructor nor getter makes a defensive copy.
+- `toString()` returns a diagnostic representation of numeric and script fields. The current representation omits the enemy name.
+- `Enemy` does not define value equality; instances compare by identity.
+
+## CSV helpers — `sg4e.ff4stats.csv`
+
+### `CSVParser`
+
+- `CSVParser(String csvfile) throws IOException` — opens a system-class-loader resource, applies Apache Commons CSV RFC 4180 parsing with its first record as headers, and wraps all data rows.
+- `public final List<RecordParser> Records` — an unmodifiable list when the resource exists; `null` when no resource exists at that path. The capitalized field name is part of the public API.
+
+Streams/readers are not explicitly closed by this implementation. Prefer this helper for small packaged resources, which is how the library uses it.
+
+### `RecordParser`
+
+Typed access around one Apache Commons `CSVRecord`.
+
+- `RecordParser(CSVRecord record)` — wraps the supplied record.
+- `int getInteger(int index)` / `int getInteger(String header)` — parse an integer, returning zero on `NumberFormatException`.
+- `int getInteger(int index, int defaultValue)` / header overload — return the supplied default on `NumberFormatException`.
+- `String getString(int index)` / header overload — return raw cell text.
+- `Boolean getBoolean(int index)` / header overload — delegate to `Boolean.parseBoolean`.
+- `int size()` — return the number of values in the record.
+
+Only malformed integer content is defaulted. Invalid indices or unknown headers can still throw exceptions from Commons CSV.
+
+## Party and equipment — `sg4e.ff4stats.party`
+
+### `Stats`
+
+A five-integer stat tuple ordered as strength, agility, vitality, wisdom, and willpower.
+
+- `Stats(int str, int agi, int vit, int wis, int will)` — creates a tuple with no range validation.
+- Getters return each component.
+- `equals(Object)` / `hashCode()` compare all five components.
+- No arithmetic helpers or custom `toString()` are provided.
+
+### `Equipment`
+
+Shared interface implemented by `Weapon` and `Armor`:
+
+- `String getName()`
+- `String getType()`
+- `Stats getStats()` — primary-stat modifiers associated with the equipment.
+
+### `Weapon`
+
+- `Weapon(String name, String type, int atk, int hitPercentage, Stats stats, boolean throwable)` — constructs an independent weapon with no validation.
+- Getters: `getName()`, `getType()`, `getStats()`, `getAttack()`, `getHitPercentage()`, and `isThrowable()`.
+- `static Weapon getWeapon(String name, String type)` — lowercases both arguments and performs a catalog lookup; returns `null` when absent. Passing `null` causes a `NullPointerException` during lowercasing.
+- No value equality or `toString()` override is defined.
+
+### `Armor`
+
+- `Armor(String name, String type, int def, int evade, int magDef, int magEvade, Stats stats)` — constructs independent armor with no validation.
+- Getters: `getName()`, `getType()`, `getStats()`, `getDefense()`, `getEvasion()`, `getMagicDefense()`, and `getMagicEvasion()`.
+- `static Armor getArmor(String name, String type)` — lowercases both arguments and performs a catalog lookup; returns `null` when absent. Passing `null` causes a `NullPointerException`.
+- No value equality or `toString()` override is defined.
+
+### `GrowthTable`
+
+Stores eight `Stats` deltas used for post-level-70 growth.
+
+- The constructor requires eight `Stats` arguments, corresponding to indices `0` through `7`.
+- `Stats get(int index)` returns one row. Intended valid indices are `0..7`. Avoid index `8`; despite the explicit bounds check's message, the implementation allows it past that check and the array access then throws `ArrayIndexOutOfBoundsException`.
+
+### `LevelData`
+
+Character progression catalog. Constants are `DARK_KNIGHT_CECIL`, `KAIN`, `RYDIA`, `TELLAH`, `EDWARD`, `ROSA`, `YANG`, `POROM`, `PALOM`, `PALADIN_CECIL`, `CID`, `EDGE`, and `FUSOYA`.
+
+- `int getLevelForTotalExperience(int totalXp)` — returns the level whose XP range contains the value. Values beyond represented ranges can result in a failed lookup/unboxing error; use valid game XP.
+- `Stats getStatsForLevel(int level)` — deterministic base/growth-table result.
+- `Stats getStatsForTotalExperience(int totalXp)` — converts XP to level, then calls deterministic stat calculation.
+- `Stats getMinStatsForLevel(int level)` / `getMaxStatsForLevel(int level)` — possible per-stat bounds, especially relevant above level 70.
+- `GrowthTable getGrowthTable()` — returns the character's eight post-70 growth rows.
+- `int getStartingLevel()` — returns the first level represented by the character resource.
+- `int getMinimumXpForLevel(int level)` — inclusive lower XP threshold.
+- `int getMaximumXpForLevel(int level)` — exclusive upper XP threshold; level 99 uses `Integer.MAX_VALUE`.
+- `int getStartingHp()` / `getStartingMp()` — return the enum constant's starting values.
+- `Range<Integer> getHpRangeAtLevel(int level)` / `getMpRangeAtLevel(int level)` — return closed cumulative possible ranges, capped at 9,999 HP and 999 MP.
+- `toString()` — returns the character's display name.
+
+Use supported character levels from `getStartingLevel()` through 99. Several methods assume valid levels and can fail indirectly for out-of-range input rather than throw a curated validation exception.
+
+### `PartyMember`
+
+A mutable progression state backed by one `LevelData` constant.
+
+- `PartyMember(LevelData data)` — begins at that character's catalog starting level and minimum XP.
+- `PartyMember(LevelData data, int startingLevel)` — begins at a selected level. Rejects levels below the character's start or above 99.
+- `void gainXp(int xpGained)` — adds the delta, recalculates level/min/max stats, and emits changed `xp`, `level`, and `stats` properties.
+- `void resetXp()` — resets using configured starting XP/level; absent settings fall back to zero XP and/or a derived level as implemented.
+- `Integer getStartingLevel()` / `getStartingXP()` — nullable reset configuration, not necessarily the current starting state used by the constructor.
+- `void setStartingLevel(Integer level)` — validates nullable reset level and emits `Start Level`; does not update current state.
+- `void setStartingXp(Integer xp)` — when both XP and a starting level are non-null, validates XP against that level's range and emits `Start XP`; does not update current state.
+- Current-state getters: `getLevel()`, `getXp()`, `getStats()` (minimum/current deterministic lower value), `getStatsMax()`, and `getData()`.
+- Listener methods: `addPropertyChangeListener(...)`, `removePropertyChangeListener(...)`, and `hasPropertyChangeListener(...)`.
+
+## FF4FE flags and key items — `sg4e.ff4stats.fe`
+
+### `Flag`
+
+- `Flag(String name, int offset, int size, int value, FlagVersion version)` — creates a version-owned bit-field choice.
+- Getters expose every field.
+- `compareTo(Flag)` orders flags by the owning version's natural specification order.
+- No equality/hash/string override is defined; flag identity and canonical names are both used by different implementation paths.
+
+### `FlagVersion`
+
+Supported constants: `VERSION_3_0`, `VERSION_3_4`, `VERSION_3_5`, `VERSION_3_7`, `VERSION_4_0_0`, and `VERSION_4_5_0`.
+
+Public constants `latest` (`"4.5.0"`) and `earliest` (`"0.3.0"`) describe the implementation's advertised range.
+
+- `FlagRules getFlagRules()` — returns parsed rules; primarily for internal use.
+- `String getSeperator()` — returns readable grouping separator using the historical spelling.
+- `String getBinaryFlagVersion()` — returns the binary representation prefix for this spec.
+- `List<Flag> getAllFlags()` — returns the live specification list; treat it as read-only.
+- `Flag getFlagByName(String name)` — exact canonical-name lookup, or `null`.
+- `String getVersion()` — decodes the binary version marker into dotted notation.
+- `static Flag getFlagFromFlagString(FlagVersion version, String flag, Flag previousFlag)` — resolves a readable token according to grouping context; mainly an internal parsing helper.
+- `static FlagVersion getVersionFromFlagString(String flag)` — probes newest-to-oldest specs for a readable flag.
+- `static FlagVersion getFromVersionString(String version)` — maps dotted versions and aliases; unknown values warn and fall back to `VERSION_4_5_0`.
+
+### `FlagRules`
+
+`FlagRules` has a public zero-argument constructor, but its useful top-level operations are protected and nested rule types are package-private. It is exposed by `FlagVersion` for implementation purposes, not designed as a standalone consumer API. Use `FlagSet` to obtain rule-normalized behavior.
+
+### `FlagSet`
+
+A parsed and normalized collection of flags plus version, binary text, optional seed, and readable formatting state. It has no public constructor; use factory methods.
+
+Factories:
+
+- `static FlagSet from(String string)` — returns `null` for `null`/empty; otherwise tries URL, binary, then readable parsing.
+- `static FlagSet fromUrl(String url)` — parse supported FF4FE URL forms; malformed URLs/unsupported forms raise `IllegalArgumentException` after URL parsing attempts.
+- `static FlagSet fromString(String text)` — parse, infer version, apply rules, normalize text, and encode binary.
+- `static FlagSet fromBinary(String binary)` — decode version, flags, and optional seed; rejects non-binary format.
+
+Access and formatting:
+
+- `String getVersion()` — dotted version decoded or inferred for the set.
+- `String getSeed()` / `boolean hasSeed()` — inspect optional seed identifier.
+- `String getBinary()` — binary flag string retained/generated by parsing.
+- `Boolean contains(String flagString)` — exact lookup by canonical flag name.
+- `NavigableSet<Flag> getFlags()` — sorted defensive copy.
+- `toString()` — selected normalized style: canonical for modern versions and legacy for older versions.
+- `toStringLegacyStyle()` — grouped legacy formatting.
+- `toStringCanonical()` — modern canonical formatting.
+- `String toFlagUrl()` — FF4FE make URL with binary flags.
+- `String toSeedUrl()` — FF4FE seed URL, or `null` without a seed.
+
+Protected `rawAdd`, `add`, and `remove` are available to subclasses/package implementation. Rule-aware `add`/`remove` can alter related flags.
+
+### `KeyItem`
+
+Enum constants: `CRYSTAL`, `PASS`, `HOOK`, `DARKNESS`, `EARTH`, `TWIN_HARP`, `PACKAGE`, `SAND_RUBY`, `BARON_KEY`, `MAGMA_KEY`, `TOWER_KEY`, `LUCA_KEY`, `ADAMANT`, `LEGEND`, `PAN`, `SPOON`, `RAT_TAIL`, and `PINK_TAIL`.
+
+`toString()` returns a human-readable display name such as `"Darkness Crystal"` rather than the enum identifier.
+
+### `KeyItemLocation`
+
+Declared locations: `START`, `ANTLION`, `FABUL`, `ORDEALS`, `BARON_INN`, `BARON_CASTLE`, `TOROIA`, `DARK_ELF`, `ZOT`, `TOP_BABIL`, `LOW_BABIL`, `DWARF_CASTLE`, `SEALED_CAVE`, `RAT_TAIL`, `SHEILA_PANLESS`, `SHEILA_PAN`, `SUMMONED_MONSTERS_CHEST`, `ODIN`, `LEVIATAN`, `ASURA`, `SYLPH`, `BAHAMUT`, `PALE_DIM`, `WYVERN`, `PLAGUE`, `DLUNAR`, `OGOPOGO`, `MIST`, `KOKKOL`, `OBJECTIVE`, and `ZEROMUS`.
+
+- `String getLocation()` — display name.
+- `String getAbbreviatedLocation()` — short display code.
+- `boolean isInUnderworld()` — declared underworld marker.
+- `Set<KeyItem> getRequiredItemsForAccess()` — defensive copy of direct gates.
+- `toString()` — same as display location.
+- `static List<KeyItemLocation> getAccessibleLocations(Collection<KeyItem> keyItems)` — inventory-based filter. Requires a non-null collection and returns a new list in enum declaration order.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,157 @@
+# Architecture and data flow
+
+## Repository layout
+
+```text
+build.gradle                         Gradle Java-library build and dependencies
+settings.gradle                      Names the root project FF4StatsLib
+src/main/java/sg4e/ff4stats/         Boss/enemy/formation API
+src/main/java/sg4e/ff4stats/csv/     Classpath CSV adapters
+src/main/java/sg4e/ff4stats/party/   Character, stats, and equipment API
+src/main/java/sg4e/ff4stats/fe/      FF4FE flags and key-item API
+src/main/resources/                  Packaged game and flag-spec data
+src/test/java/                       JUnit 4 regression tests
+docs/                                Maintainer and consumer documentation
+```
+
+## Package responsibilities
+
+### `sg4e.ff4stats`
+
+This package models boss substitutions. On first use, `Battle` loads `bosses.csv`, groups rows by `(boss, position)`, and creates a `Formation` containing one `Enemy` per row. A `Battle` is the map key and compares by exact boss and position strings.
+
+Data flow:
+
+```text
+bosses.csv
+  -> CSVParser / RecordParser
+  -> Battle static initializer
+  -> Map<Battle, Formation>
+  -> Formation List<Enemy>
+```
+
+`Battle.getAllBosses()` exposes an unmodifiable map. Each map value remains mutable because `Formation.addEnemy(...)` is public and `Formation.getAllEnemies()` returns its live list.
+
+### `sg4e.ff4stats.csv`
+
+`CSVParser` is a thin classpath-resource adapter around Apache Commons CSV. It uses `ClassLoader.getSystemClassLoader().getResourceAsStream(...)`, parses RFC 4180 data with a header row, wraps each Commons CSV record in `RecordParser`, and exposes an unmodifiable list through the public final `Records` field.
+
+`RecordParser` provides typed cell access. Integer parsing returns a caller-supplied default (zero by default) only for `NumberFormatException`; missing headers and invalid indices still propagate underlying errors. Boolean parsing delegates to `Boolean.parseBoolean`, so only case-insensitive `"true"` becomes `true`; all other strings become `false`.
+
+### `sg4e.ff4stats.party`
+
+This package has three layers:
+
+1. `Stats` and `Equipment` define shared data shapes.
+2. `Weapon` and `Armor` load catalog rows into case-insensitive two-dimensional lookup tables keyed by lowercase name and type.
+3. `LevelData`, `GrowthTable`, and `PartyMember` model progression.
+
+#### Equipment initialization
+
+The first active use of `Weapon` or `Armor` triggers a static initializer. It parses the corresponding CSV, creates an object per row, builds an immutable set and Guava `ImmutableTable`, and logs any load error. The set is retained internally; the table backs public lookup. Duplicate `(name, type)` keys would fail table construction and leave the static initialization path in its error behavior.
+
+#### Character progression through level 70
+
+Each `LevelData` enum constant identifies a character, starting HP/MP, a CSV resource, and eight possible post-70 growth deltas. During enum initialization, each CSV row becomes an internal level record containing:
+
+- total XP threshold;
+- level;
+- five primary stats;
+- minimum and maximum HP growth; and
+- minimum and maximum MP growth.
+
+The implementation builds maps/range maps for XP-to-level, level-to-XP, base stats, and cumulative HP/MP growth. Public methods then query those precomputed structures.
+
+#### Character progression after level 70
+
+Above level 70, the CSV's level-70 stats form the baseline. For deterministic `getStatsForLevel(level)`, every later level selects growth row `(level - 1) % 8` and adds that row's five deltas. For minimum and maximum calculations, each post-70 level independently chooses the minimum or maximum delta for each stat across all eight rows. Every resulting stat is capped at 99 on the upper end; negative post-70 results are not explicitly floored.
+
+HP and MP ranges are cumulative ranges from the CSV growth columns. They are clamped to game caps: HP up to 9,999 and MP up to 999. They are exposed as Guava closed `Range<Integer>` values.
+
+#### Mutable party members
+
+`PartyMember` wraps a `LevelData` catalog entry with mutable current XP/level/stats and optional reset settings. `gainXp(...)` recalculates level and min/max stats, then fires JavaBeans property-change events. `resetXp()` restores configured starting XP/level, or derives defaults when a setting is absent.
+
+### `sg4e.ff4stats.fe`
+
+This package handles FF4FE flags and key-item reachability.
+
+#### Flag specification model
+
+A `Flag` represents one version-specific encoded choice:
+
+| Property | Meaning |
+| --- | --- |
+| `name` | Canonical readable flag name |
+| `offset` | Starting bit offset in the binary flag payload |
+| `size` | Number of bits occupied |
+| `value` | Value that identifies the flag at that offset |
+| `version` | Owning `FlagVersion` |
+
+`FlagVersion` enumerates supported specifications: `VERSION_3_0`, `VERSION_3_4`, `VERSION_3_5`, `VERSION_3_7`, `VERSION_4_0_0`, and `VERSION_4_5_0`. Legacy versions load CSV specifications; modern versions load JSON. A version also records its binary prefix, readable grouping separator, name lookup, natural ordering, and optional parsed `FlagRules`.
+
+`Flag.compareTo(...)` delegates to its version's natural-order comparison. Comparing flags from inappropriate versions is not a supported use case. `Flag` does not override `equals`, `hashCode`, or `toString`; identity matters internally.
+
+#### Readable flag parsing
+
+`FlagSet.fromString(...)` performs these conceptual steps:
+
+1. Tokenize grouped readable flags and account for supported shorthand/group syntax.
+2. Infer a compatible version by trying specifications from newest to oldest.
+3. Resolve every canonical flag name; incompatible names cause `IllegalArgumentException`.
+4. Seed the set with base flags and apply modern JSON rules as flags are added.
+5. Sort flags in the specification's natural order.
+6. Format a normalized readable string (legacy or canonical modern style).
+7. Pack flag values at their configured bit offsets and prepend the version's binary marker.
+
+The readable representation is therefore normalized rather than guaranteed to preserve the caller's whitespace or grouping.
+
+#### Binary flag parsing
+
+`FlagSet.fromBinary(...)` validates the binary format, decodes the four-character version segment from URL-safe Base64, decodes the flag payload, and checks every flag in the selected specification. A flag is enabled when the bits at its offset equal its configured value. An optional suffix after `.` is retained as the seed identifier.
+
+Supported version aliases are mapped by `FlagVersion.getFromVersionString(...)`. Unknown future versions deliberately fall back to the latest specification with a warning. This can work when the specification is unchanged, but it cannot guarantee correct parsing after a flag-layout change.
+
+#### URL handling
+
+`FlagSet.fromUrl(...)` extracts flags and optional seed data from supported URL shapes. `toFlagUrl()` generates `https://ff4fe.com/make?flags=<binary>`. `toSeedUrl()` generates `https://ff4fe.com/seed/<seed>` only when a seed exists.
+
+#### Rule engine
+
+Modern JSON flag specifications can contain rules. A rule has nested conditions (`AND`, `OR`, `NOT`, or default behavior) and consequences that enable or disable flags. `FlagSet` invokes rules during addition/removal so implied flags and mutually dependent choices stay consistent. `FlagRules` is public only as a type; most of its useful methods and nested types are protected or package-private, so normal consumers should rely on `FlagSet` rather than call it directly.
+
+#### Key-item reachability
+
+`KeyItem` is a display-named enum. `KeyItemLocation` stores a location display name, abbreviation, underworld marker, and required item set. Accessibility is a lightweight inventory filter, not a full progression solver: it does not simulate collecting items, ordering checks, characters, objectives, or every game-world constraint.
+
+## Initialization, errors, and logging
+
+Several catalogs initialize in static blocks or enum constructors. This has practical implications:
+
+- The first reference can perform resource I/O and parsing.
+- Data stays cached for the lifetime of the class loader.
+- Most catalog-loading exceptions are caught and logged through SLF4J.
+- If an application provides no SLF4J provider, diagnostics may be limited.
+- A malformed packaged resource can lead to empty or partial data rather than an exception at the calling lookup.
+
+## Mutability and thread safety matrix
+
+| API value | Mutability visible to caller | Notes |
+| --- | --- | --- |
+| `Battle.getAllBosses()` | Map unmodifiable; values mutable | Do not mutate shared formations |
+| `Formation.getAllEnemies()` | Live mutable list | Mutates that formation |
+| `Enemy.getScriptValues()` | Live mutable list | Mutates that enemy's script data |
+| `CSVParser.Records` | Unmodifiable list | `RecordParser` wrappers are effectively read-only |
+| `Weapon`, `Armor`, `Stats`, `Battle`, `Enemy` scalar fields | Effectively immutable | Exceptions are exposed lists noted above |
+| `FlagSet.getFlags()` | Defensive `TreeSet` copy | Individual `Flag` objects are effectively immutable |
+| `FlagVersion.getAllFlags()` | Live list | Treat as read-only |
+| `KeyItemLocation.getRequiredItemsForAccess()` | Defensive set copy | Safe to mutate the returned set |
+| `KeyItemLocation.getAccessibleLocations()` | New mutable list | Does not mutate enum state |
+| `PartyMember` | Mutable | Coordinate access across threads |
+
+## Extension guidance
+
+- To update bundled data without changing behavior, edit the appropriate resource and add or update tests.
+- To add a character, add a `LevelData` enum constant, a matching party CSV, an eight-row `GrowthTable`, and progression tests.
+- To add a flag version, add the spec resource and enum constant, then update version detection/mapping and round-trip tests.
+- To add a new domain model, prefer an immutable object and defensive/unmodifiable collection views; existing live-list behavior is historical and should not be copied.

--- a/docs/data-files.md
+++ b/docs/data-files.md
@@ -1,0 +1,161 @@
+# Data files, dependencies, testing, and maintenance
+
+## Classpath resource contract
+
+All bundled data lives under `src/main/resources` and is packaged at the root of the library JAR. Code refers to paths such as `bosses.csv`, `equipment/weapons.csv`, and `party/Kain.csv`, without a leading slash.
+
+Resource-name case matters on common deployment platforms. When adding or renaming a file, update the Java reference with the exact same spelling. The loaders assume the resource schema and generally do not perform explicit schema validation, so tests are essential.
+
+## Resource inventory and schemas
+
+### `bosses.csv`
+
+Loaded by `Battle` and transformed into grouped formations. The implementation uses positional columns:
+
+| Index | Meaning |
+| ---: | --- |
+| 0 | Boss identity; title-cased for the `Battle` key |
+| 1 | Position identity; text before `_slot` is title-cased for the key |
+| 2 | Enemy name |
+| 3 | Level |
+| 4 | HP |
+| 5 | EXP |
+| 6 | GP |
+| 7 | Attack multiplier |
+| 8 | Hit percent |
+| 9 | Attack |
+| 10 | Defense multiplier |
+| 11 | Evasion percent |
+| 12 | Defense |
+| 13 | Magic-defense multiplier |
+| 14 | Magic-evasion percentage |
+| 15 | Magic defense |
+| 16 | Minimum speed |
+| 17 | Maximum speed |
+| 18 | Spell power |
+| 19+ | Script values retained as strings |
+
+Because parsing is positional, column reordering is a breaking data change even if headers remain descriptive.
+
+### `equipment/weapons.csv`
+
+Loaded by header name. Required headers are `name`, `type`, `atk`, `hitPercentage`, `str`, `agi`, `vit`, `wis`, `will`, and `canThrow`. Catalog lookup keys are lowercase `(name, type)`; preserve unique pairs.
+
+### `equipment/armor.csv`
+
+Loaded by header name. Required headers are `name`, `type`, `def`, `evade`, `magDef`, `magEvade`, `str`, `agi`, `vit`, `wis`, and `will`. Catalog lookup keys are lowercase `(name, type)`; preserve unique pairs.
+
+### `party/*.csv`
+
+Each character resource is referenced by one `LevelData` constant. Required headers are:
+
+| Header | Meaning |
+| --- | --- |
+| `xp` | Total experience threshold for the row's level |
+| `level` | Character level |
+| `str`, `agi`, `vit`, `wis`, `will` | Primary stats at that level |
+| `minHpGrowth`, `maxHpGrowth` | Possible HP increment represented by the row |
+| `minMpGrowth`, `maxMpGrowth` | Possible MP increment represented by the row |
+
+The code relies on complete, consistent level and XP ranges. The first represented level becomes `getStartingLevel()`. Level 70 is the baseline for post-70 primary-stat growth. HP/MP range maps are built cumulatively from the rows.
+
+### `fe/flagVersions/*.csv`
+
+Legacy flag specifications use positional columns:
+
+1. canonical flag name;
+2. bit offset;
+3. bit width; and
+4. encoded value.
+
+Each row becomes a `Flag` in natural display/compare order.
+
+### `fe/flagVersions/*.json`
+
+Modern flag specifications provide a `binary` array containing objects with `name`, `offset`, `size`, and `value`, plus rule data consumed by `FlagRules`. The JSON parsers advance through an expected token layout; preserve the established structure and field ordering unless the parser is updated too.
+
+## Dependencies
+
+| Dependency | Role in the implementation |
+| --- | --- |
+| Apache Commons CSV | RFC 4180 CSV parsing and header/cell access |
+| Apache Commons Text | Title-casing boss and position keys while loading `bosses.csv` |
+| Guava | Immutable equipment tables, immutable/range maps, ranges, and flag ordering helpers |
+| Jackson Databind/Core | Streaming parsing of modern FF4FE JSON specifications and rules |
+| SLF4J API | Logging resource-load and flag-version warnings/errors |
+| SLF4J Simple (test only) | Makes logs visible during tests |
+| JUnit 4 (test only) | Regression tests |
+
+The Gradle build declares runtime libraries with `implementation`, not `api`. Consumers building against public signatures that mention Guava (`LevelData` range methods) or Commons CSV (`RecordParser` constructor) may need to declare those dependencies explicitly depending on how the library is integrated.
+
+## Existing test coverage
+
+The JUnit suite checks:
+
+- `Battle` equality and hash-code behavior;
+- weapon and armor catalog loading;
+- character base stats and growth-table values;
+- key-item accessibility;
+- individual flag behavior;
+- readable flag parsing and normalization;
+- binary flag encoding/decoding and round trips across versions; and
+- modern/legacy compatibility behavior and malformed flags.
+
+Run all checks with:
+
+```bash
+./gradlew clean test
+```
+
+Generate the JAR and all standard verification outputs with:
+
+```bash
+./gradlew build
+```
+
+## Maintenance workflows
+
+### Change boss or enemy data
+
+1. Edit `src/main/resources/bosses.csv` without reordering the fixed positional columns.
+2. Confirm boss/position normalization gives the intended lookup strings.
+3. Add a test that calls `Formation.getFor(...)` and validates representative enemy fields and script values.
+4. Run the full test suite.
+
+### Change equipment data
+
+1. Edit the appropriate equipment CSV while retaining all required headers.
+2. Ensure every lowercase `(name, type)` pair is unique.
+3. Add or update lookup tests, including primary-stat modifiers.
+4. Run the full test suite.
+
+### Change character progression data
+
+1. Edit the character CSV while preserving complete level/XP ordering and required headers.
+2. If post-70 growth changes, edit the character's `GrowthTable` in `LevelData`.
+3. Test starting level, representative pre-70 levels, level 70, post-70 deterministic stats, min/max stats, XP boundaries, and HP/MP ranges.
+4. Run the full test suite.
+
+### Add or change an FF4FE flag specification
+
+1. Add/update the corresponding CSV or JSON resource.
+2. For a new version, add a `FlagVersion` constant with the correct resource name, binary marker, and grouping separator.
+3. Update newest-to-oldest version detection and dotted-version alias mapping.
+4. Add readable-to-binary and binary-to-readable fixtures, rule implication tests, URL/seed tests, and cross-version compatibility tests.
+5. Run the full test suite.
+
+### Evolve public API safely
+
+This project has no explicit semantic-version configuration, but consumers can compile directly against every public class and method. Preserve public names—including historical misspellings—unless making an intentional breaking change. Prefer adding overloads/new methods over changing signatures. When returning new collections, prefer defensive or unmodifiable views rather than repeating existing live-list behavior.
+
+## Known implementation risks worth testing around
+
+- Missing resources can yield `null` lists or empty catalogs after logged errors.
+- Static catalog data can be modified through live formation/enemy/flag-spec lists.
+- Out-of-range levels/XP often fail indirectly rather than through explicit validation.
+- `GrowthTable.get(8)` reaches an array-bounds exception despite its custom check suggesting a curated illegal-argument error.
+- Modern JSON flag parsing depends on the expected token structure/order.
+- Unknown binary flag versions fall back to the latest known version.
+- Equipment lookup lowercases using the JVM's default locale; unusual locale settings may affect certain strings.
+
+When fixing one of these behaviors, add a regression test and document whether the change is backward-compatible.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,197 @@
+# Getting started and common recipes
+
+## Build from source
+
+Requirements: a JDK capable of building Java 8-targeted code. The repository includes Gradle Wrapper scripts, so a separate Gradle installation is unnecessary.
+
+```bash
+# Linux/macOS
+./gradlew clean test
+./gradlew build
+
+# Windows
+./gradlew.bat clean test
+./gradlew.bat build
+```
+
+The JAR is emitted beneath `build/libs/`. The project is a library and has no `main` method to run.
+
+## Consume the library
+
+### Composite/multi-project Gradle build
+
+Because this repository does not publish coordinates, the most direct development setup is to include it as a project and then declare an implementation dependency:
+
+```groovy
+// settings.gradle in a containing build
+include ':FF4StatsLib'
+project(':FF4StatsLib').projectDir = file('../FF4StatsLib')
+```
+
+```groovy
+// consuming project's build.gradle
+dependencies {
+    implementation project(':FF4StatsLib')
+}
+```
+
+The Java Library plugin exposes FF4StatsLib's public classes. At runtime, ensure its declared implementation dependencies are also present. If copying only the built JAR manually, resolve the dependencies listed in `build.gradle` yourself.
+
+## Recipe: inspect a boss formation
+
+```java
+import sg4e.ff4stats.Enemy;
+import sg4e.ff4stats.Formation;
+
+Formation formation = Formation.getFor("Antlion", "Bahamut");
+if (formation == null) {
+    System.out.println("No matching boss/position pair");
+} else {
+    for (Enemy enemy : formation.getAllEnemies()) {
+        System.out.printf("%s: level %d, HP %d, XP %d%n",
+                enemy.getName(), enemy.getLevel(), enemy.getHp(), enemy.getExp());
+    }
+}
+```
+
+A formation lookup is exact and case-sensitive. To discover valid pairs, iterate the catalog:
+
+```java
+import java.util.Map;
+import sg4e.ff4stats.Battle;
+import sg4e.ff4stats.Formation;
+
+for (Map.Entry<Battle, Formation> entry : Battle.getAllBosses().entrySet()) {
+    System.out.println(entry.getKey() + " -> " + entry.getValue());
+}
+```
+
+`Battle.toString()` produces `boss + " @ " + position`. The map itself is unmodifiable, but formations and their enemy lists should be treated as read-only to avoid modifying the shared catalog.
+
+## Recipe: look up equipment
+
+```java
+import sg4e.ff4stats.party.Armor;
+import sg4e.ff4stats.party.Stats;
+import sg4e.ff4stats.party.Weapon;
+
+Weapon crystalSword = Weapon.getWeapon("crystal", "sword");
+if (crystalSword != null) {
+    Stats bonus = crystalSword.getStats();
+    System.out.printf("%s: %d attack, %d%% hit, +%d strength%n",
+            crystalSword.getName(), crystalSword.getAttack(),
+            crystalSword.getHitPercentage(), bonus.getStrength());
+}
+
+Armor armor = Armor.getArmor("adamant", "armor");
+if (armor != null) {
+    System.out.printf("%s: %d defense, %d magic defense%n",
+            armor.getName(), armor.getDefense(), armor.getMagicDefense());
+}
+```
+
+Both equipment lookup methods normalize `name` and `type` to lowercase, so their arguments are case-insensitive. They return `null` when no matching row exists. A name can occur under different types, which is why both dimensions are required.
+
+## Recipe: calculate character progression
+
+For stateless calculations, call `LevelData` directly:
+
+```java
+import com.google.common.collect.Range;
+import sg4e.ff4stats.party.LevelData;
+import sg4e.ff4stats.party.Stats;
+
+LevelData yang = LevelData.YANG;
+int level = yang.getLevelForTotalExperience(100_000);
+Stats deterministic = yang.getStatsForLevel(level);
+Stats minimum = yang.getMinStatsForLevel(level);
+Stats maximum = yang.getMaxStatsForLevel(level);
+Range<Integer> hpRange = yang.getHpRangeAtLevel(level);
+
+System.out.printf("Level %d, STR %d..%d, HP %s%n",
+        level, minimum.getStrength(), maximum.getStrength(), hpRange);
+```
+
+For a mutable character that gains XP and emits JavaBeans property changes, use `PartyMember`:
+
+```java
+import sg4e.ff4stats.party.LevelData;
+import sg4e.ff4stats.party.PartyMember;
+
+PartyMember member = new PartyMember(LevelData.KAIN);
+member.addPropertyChangeListener(event ->
+        System.out.printf("%s: %s -> %s%n",
+                event.getPropertyName(), event.getOldValue(), event.getNewValue()));
+member.gainXp(5_000);
+```
+
+The events emitted by XP operations use property names `xp`, `level`, and `stats`. Changing reset configuration emits `Start Level` and `Start XP`. `setStartingLevel(...)` and `setStartingXp(...)` configure what a later `resetXp()` does; they do not immediately change current XP, level, or stats.
+
+## Recipe: parse and inspect FF4FE flags
+
+`FlagSet.from(...)` is the convenient dispatcher. It recognizes an FF4FE URL, a binary string beginning with `b`, or a human-readable flag string:
+
+```java
+import sg4e.ff4stats.fe.FlagSet;
+
+FlagSet flags = FlagSet.from("Kmain Pkey Cstandard Twild");
+System.out.println(flags.toString());       // normalized readable form
+System.out.println(flags.getBinary());      // URL-safe binary representation
+System.out.println(flags.getVersion());     // decoded flag-spec version
+System.out.println(flags.contains("Kmain"));
+System.out.println(flags.toFlagUrl());
+```
+
+Direct parsers are also available:
+
+```java
+FlagSet human = FlagSet.fromString("Kmain Pkey Cstandard Twild");
+FlagSet binary = FlagSet.fromBinary(human.getBinary());
+FlagSet url = FlagSet.fromUrl("https://ff4fe.com/make?flags=" + human.getBinary());
+```
+
+Important parsing behavior:
+
+- `from(null)` and `from("")` return `null`.
+- `from(...)` tries URL, binary, then readable-string parsing.
+- Readable parsing identifies a compatible `FlagVersion`, applies version rules, and produces a normalized readable string and binary string.
+- Binary parsing decodes the embedded version and enabled bit fields. A binary string can optionally carry a seed suffix separated by `.`.
+- Invalid or incompatible input produces `IllegalArgumentException` from the direct parser; `from(...)` may try another representation before ultimately failing readable parsing.
+- `contains(...)` expects a complete canonical flag name, not a grouped display fragment.
+
+Use `toSeedUrl()` only when `hasSeed()` is true; otherwise it returns `null`. `toFlagUrl()` always creates an FF4FE make URL containing the binary flags.
+
+## Recipe: determine accessible key-item locations
+
+```java
+import java.util.EnumSet;
+import java.util.List;
+import sg4e.ff4stats.fe.KeyItem;
+import sg4e.ff4stats.fe.KeyItemLocation;
+
+EnumSet<KeyItem> inventory = EnumSet.of(KeyItem.MAGMA_KEY, KeyItem.BARON_KEY);
+List<KeyItemLocation> accessible = KeyItemLocation.getAccessibleLocations(inventory);
+for (KeyItemLocation location : accessible) {
+    System.out.printf("%s (%s)%n",
+            location.getLocation(), location.getAbbreviatedLocation());
+}
+```
+
+The algorithm starts with every declared location, removes underworld locations unless the inventory has `MAGMA_KEY` or `HOOK`, removes `ZEROMUS` unless it has `PASS` or `DARKNESS`, and removes locations whose declared required-item set is not contained in the inventory. The returned list is a new mutable list.
+
+## Recipe: read an additional classpath CSV
+
+```java
+import sg4e.ff4stats.csv.CSVParser;
+import sg4e.ff4stats.csv.RecordParser;
+
+CSVParser parser = new CSVParser("my-data.csv");
+if (parser.Records != null) {
+    for (RecordParser row : parser.Records) {
+        String name = row.getString("name");
+        int value = row.getInteger("value", -1);
+    }
+}
+```
+
+The file must be visible to the system class loader. The first row is interpreted as headers using RFC 4180 rules. A missing resource does not throw: `Records` is set to `null`. A present but unreadable/malformed file can throw `IOException` from the constructor.


### PR DESCRIPTION
### Motivation

- Provide a single, thorough documentation set at the repository root that explains the library purpose, runtime/build expectations, public API, resource formats, and maintenance workflows.
- Make it easy for integrators and maintainers to discover how to build, consume, and extend the library without reading source code.

### Description

- Add a new top-level `docs/` directory containing `README.md`, `getting-started.md`, `architecture.md`, `api-reference.md`, and `data-files.md` with comprehensive guidance and examples.
- Document package responsibilities, resource loading semantics, deterministic vs. possible stat growth rules, FF4FE flag parsing/encoding behavior, and known behavioral caveats (including historical method spellings and mutability considerations).
- Describe resource schemas for `bosses.csv`, `party/*.csv`, `equipment/*.csv`, and `fe/flagVersions/*`, list runtime dependencies, and provide maintenance and testing workflows.
- Commit the new documentation and create a pull request titled "Add comprehensive project and API documentation" (commit `291ac61`).

### Testing

- Verified relative Markdown links with a custom Python check and confirmed all links resolve (success).
- Ran `git diff --cached --check` to validate whitespace and staging (success).
- Executed the existing test suite with `./gradlew test` (JUnit) and performed a full build with `./gradlew build`, both of which completed successfully.
- Confirmed the repository status after the commit and the generated diff/stat show only the new `docs/` files were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23e5c1b400832d97c9818ec63ffb88)